### PR TITLE
chore: add .tractusx metafile

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "Managed-Simple-Data-Exchanger-Backend"
+leadingRepository: "https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend"
+repositories:
+- name: "managed-simple-data-exchanger-backend"
+  usage: "reference implementation of Managed-Simple-Data-Exchanger-Backend"
+  url: "https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend"

--- a/.tractusx
+++ b/.tractusx
@@ -1,6 +1,20 @@
-product: "Managed-Simple-Data-Exchanger-Backend"
-leadingRepository: "https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend"
-repositories:
-- name: "managed-simple-data-exchanger-backend"
-  usage: "reference implementation of Managed-Simple-Data-Exchanger-Backend"
-  url: "https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend"
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+leadingRepository: "https://github.com/eclipse-tractusx/managed-simple-data-exchanger"


### PR DESCRIPTION
## add Metadata file for this repo

This PR adds an initial version of the `.tractusx` metadata file like described in [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5).
If there are any other repositories, that are connected to the this repository, that together form a product, please point that out or add the connected repos later on


Fixes #33 