### PR TITLE
[feat|sde-v2.1.0] DDTR update, support for batch model v2.0 ,added external specific asset id and feign Client changes updated for child aspect relationship.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [2.1.0] - 2023-08-30
+### Fixed
+- Added external subject in specific asset Ids.
+- Update AAS submodel endpoints subprotocolBody.
+- Supported Batch submodel version 2.0.0.
+- DDTR update with latest version.
+- Feign Client changes updated for child aspect relationship.
+
+## [2.0.11] - 2023-08-29
+### Changed 
+- Docker image name changed.
+
 ## [2.0.10] - 2023-08-23
 ### Fixed
 - Updated openAPI file for kics issue.
@@ -203,9 +215,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Compliance with Catena-X Guidelines
 - Integration with Digital Twin registry service.
 
-[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/dftbackend-2.0.10...main
-[2.0.10]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/dftbackend-2.0.9...dftbackend-2.0.10
-[2.0.9]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/dftbackend-2.0.8...dftbackend-2.0.9
+[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.1.0...main
+[2.1.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.0.11...v2.1.0
+[2.0.11]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.0.10...v2.0.11
+[2.0.10]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/sdebackend-2.0.9...v2.0.10
+[2.0.9]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/sdebackend-2.0.8...sdebackend-2.0.9
 [2.0.8]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/dftbackend-2.0.2...dftbackend-2.0.8
 [2.0.2]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/dftbackend-2.0.1...dftbackend-2.0.2
 [2.0.1]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/dftbackend-2.0.0...dftbackend-2.0.1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,7 +31,7 @@ For more details, please refer configuration section from [README.md](README.md)
 - Postgres 11.9.13
 
 #### Steps
-1. Clone the GitHub Repository - https://github.com/eclipse-tractusx/dft-backend.
+1. Clone the GitHub Repository - https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend.
 2. Get your instance of postgres running (Create **dftdb** new database).
 3. Setup your project environment to JDK 18.
 4. Provide require application configuration in application.properties as specified in step configuration.properties.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/constants/CommonConstants.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/constants/CommonConstants.java
@@ -37,13 +37,13 @@ public class CommonConstants {
 	public static final String MANUFACTURER_ID = "manufacturerId";
 	public static final String CUSTOMER_PART_ID = "customerPartId";
 	public static final String ASSET_LIFECYCLE_PHASE = "assetLifecyclePhase";
-	public static final String HTTP = "http";
+	public static final String HTTP = "HTTP";
 	public static final String HTTPS = "HTTPS";
-	public static final String ENDPOINT_PROTOCOL_VERSION = "0.1";
+	public static final String ENDPOINT_PROTOCOL_VERSION = "1.1";
 	public static final String PREFIX = "urn:uuid:";
 
 	public static final String INTERFACE_EDC = "EDC";
-	public static final String SUB_PROTOCOL = "IDS";
+	public static final String SUB_PROTOCOL = "DSP";
 	public static final String SUBMODEL_CONTEXT_URL = "/submodel";
 
 	public static final String AS_PLANNED = "AsPlanned";
@@ -51,6 +51,6 @@ public class CommonConstants {
 	public static final String EXTERNAL_REFERENCE = "ExternalReference";
 	public static final String GLOBAL_REFERENCE = "GlobalReference";
 	public static final String BODY_ENCODING = "plain";
-	public static final String INTERFACE = "https://admin-shell.io/aas/API/3/0/SubmodelServiceSpecification/SSP-003";
+	public static final String INTERFACE = "SUBMODEL-3.0";
 	
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/ExternalSubjectId.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/ExternalSubjectId.java
@@ -1,7 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW GmbH
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 T-Systems International GmbH
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,40 +18,26 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-package org.eclipse.tractusx.sde.digitaltwins.entities.request;
+package org.eclipse.tractusx.sde.digitaltwins.entities.common;
 
 import java.util.List;
 
-import org.eclipse.tractusx.sde.digitaltwins.entities.common.MultiLanguage;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 
+@Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(Include.NON_NULL)
-public class ShellDescriptorRequest {
+public class ExternalSubjectId {
+	
+	private String type;
+	
+	private List<Keys> keys;
 
-    private String idShort;
-    private String id;
-    private List<MultiLanguage> description;
-    private String globalAssetId;
-    private List<Object> specificAssetIds;
-
-    @SneakyThrows
-    public String toJsonString() {
-        final ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/KeyValuePair.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/KeyValuePair.java
@@ -21,15 +21,31 @@
 
 package org.eclipse.tractusx.sde.digitaltwins.entities.common;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 
 @Data
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class KeyValuePair {
 
     private String name;
     private String value;
+    private ExternalSubjectId externalSubjectId;
+    
+    @SneakyThrows
+    public String toJsonString() {
+        final ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/LookupQuery.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/LookupQuery.java
@@ -1,7 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW GmbH
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 T-Systems International GmbH
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,41 +17,28 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-
-package org.eclipse.tractusx.sde.digitaltwins.entities.request;
+package org.eclipse.tractusx.sde.digitaltwins.entities.common;
 
 import java.util.List;
 
-import org.eclipse.tractusx.sde.digitaltwins.entities.common.MultiLanguage;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 
+@Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(Include.NON_NULL)
-public class ShellDescriptorRequest {
+public class LookupQuery {
+	
+	private String type;
+	private List<KeyValuePair> assetIds;
+	private List<String> semanticIds;
+	
+	
 
-    private String idShort;
-    private String id;
-    private List<MultiLanguage> description;
-    private String globalAssetId;
-    private List<Object> specificAssetIds;
-
-    @SneakyThrows
-    public String toJsonString() {
-        final ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/ProtocolInformation.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/ProtocolInformation.java
@@ -45,4 +45,6 @@ public class ProtocolInformation {
     private String subProtocol;
     private String subprotocolBody;
     private String subprotocolBodyEncoding;
+    private List<SecurityAttributes> securityAttributes;
+    
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/SecurityAttributes.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/common/SecurityAttributes.java
@@ -1,7 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW GmbH
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 T-Systems International GmbH
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,41 +17,25 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-
-package org.eclipse.tractusx.sde.digitaltwins.entities.request;
-
-import java.util.List;
-
-import org.eclipse.tractusx.sde.digitaltwins.entities.common.MultiLanguage;
+package org.eclipse.tractusx.sde.digitaltwins.entities.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 
+@Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(Include.NON_NULL)
-public class ShellDescriptorRequest {
+public class SecurityAttributes {
+	
 
-    private String idShort;
-    private String id;
-    private List<MultiLanguage> description;
-    private String globalAssetId;
-    private List<Object> specificAssetIds;
+	private String type;
+	private String key;
+	private String value;
 
-    @SneakyThrows
-    public String toJsonString() {
-        final ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/request/ShellLookupQueryRequest.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/entities/request/ShellLookupQueryRequest.java
@@ -1,7 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022 BMW GmbH
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 T-Systems International GmbH
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,41 +17,24 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-
 package org.eclipse.tractusx.sde.digitaltwins.entities.request;
 
-import java.util.List;
-
-import org.eclipse.tractusx.sde.digitaltwins.entities.common.MultiLanguage;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.tractusx.sde.digitaltwins.entities.common.LookupQuery;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(Include.NON_NULL)
-public class ShellDescriptorRequest {
+public class ShellLookupQueryRequest {
+	
+    private LookupQuery query;
 
-    private String idShort;
-    private String id;
-    private List<MultiLanguage> description;
-    private String globalAssetId;
-    private List<Object> specificAssetIds;
+	
+	
 
-    @SneakyThrows
-    public String toJsonString() {
-        final ObjectMapper mapper = new ObjectMapper();
-        return mapper.writeValueAsString(this);
-    }
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/facilitator/DigitalTwinsUtility.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/facilitator/DigitalTwinsUtility.java
@@ -19,22 +19,30 @@
  ********************************************************************************/
 package org.eclipse.tractusx.sde.digitaltwins.facilitator;
 
+import static org.eclipse.tractusx.sde.common.constants.CommonConstants.ASSET_LIFECYCLE_PHASE;
+import static org.eclipse.tractusx.sde.common.constants.CommonConstants.MANUFACTURER_PART_ID;
+
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.tractusx.sde.common.constants.CommonConstants;
 import org.eclipse.tractusx.sde.common.utils.UUIdGenerator;
 import org.eclipse.tractusx.sde.digitaltwins.entities.common.Endpoint;
+import org.eclipse.tractusx.sde.digitaltwins.entities.common.ExternalSubjectId;
 import org.eclipse.tractusx.sde.digitaltwins.entities.common.KeyValuePair;
 import org.eclipse.tractusx.sde.digitaltwins.entities.common.Keys;
 import org.eclipse.tractusx.sde.digitaltwins.entities.common.ProtocolInformation;
+import org.eclipse.tractusx.sde.digitaltwins.entities.common.SecurityAttributes;
 import org.eclipse.tractusx.sde.digitaltwins.entities.common.SemanticId;
 import org.eclipse.tractusx.sde.digitaltwins.entities.request.CreateSubModelRequest;
 import org.eclipse.tractusx.sde.digitaltwins.entities.request.ShellDescriptorRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -46,6 +54,8 @@ import lombok.SneakyThrows;
 @Getter
 public class DigitalTwinsUtility {
 
+	private static final String PUBLIC_READABLE = "PUBLIC_READABLE";
+
 	@Value(value = "${manufacturerId}")
 	public String manufacturerId;
 
@@ -54,81 +64,112 @@ public class DigitalTwinsUtility {
 
 	ObjectMapper mapper = new ObjectMapper();
 
+	private static final Map<String, List<String>> publicReadableSpecificAssetIDs = Map.of(MANUFACTURER_PART_ID,
+			List.of("*"), ASSET_LIFECYCLE_PHASE, List.of("AsBuilt", "AsPlanned"));
+
 	@SneakyThrows
 	public ShellDescriptorRequest getShellDescriptorRequest(Map<String, String> specificIdentifiers, Object object) {
 
 		JsonNode jsonNode = mapper.convertValue(object, ObjectNode.class);
 
+		List<String> bpns = getFieldFromJsonNodeArray(jsonNode, "bpn_numbers");
+
 		return ShellDescriptorRequest.builder()
 				.idShort(String.format("%s_%s_%s", getFieldFromJsonNode(jsonNode, "name_at_manufacturer"),
 						manufacturerId, getFieldFromJsonNode(jsonNode, "manufacturer_part_id")))
 				.globalAssetId(getFieldFromJsonNode(jsonNode, "uuid"))
-				.specificAssetIds(getSpecificAssetIds(specificIdentifiers))
-				.description(List.of())
-				.id(UUIdGenerator.getUrnUuid())
-				.build();
+				.specificAssetIds(getSpecificAssetIds(specificIdentifiers, bpns)).description(List.of())
+				.id(UUIdGenerator.getUrnUuid()).build();
 	}
 
 	@SneakyThrows
 	public CreateSubModelRequest getCreateSubModelRequest(String shellId, String sematicId, String idShortofModel) {
 		String identification = UUIdGenerator.getUrnUuid();
-		
-		SemanticId semanticId = SemanticId.builder()
-				.type(CommonConstants.EXTERNAL_REFERENCE)
-				.keys(List.of(new Keys(CommonConstants.GLOBAL_REFERENCE,sematicId)))
-				.build();
+
+		SemanticId semanticId = SemanticId.builder().type(CommonConstants.EXTERNAL_REFERENCE)
+				.keys(List.of(new Keys(CommonConstants.GLOBAL_REFERENCE, sematicId))).build();
 
 		List<Endpoint> endpoints = prepareDtEndpoint(shellId, identification);
 
-		return CreateSubModelRequest.builder()
-				.id(identification)
-				.idShort(idShortofModel)
-				.semanticId(semanticId)
-				.endpoints(endpoints)
-				.build();
+		return CreateSubModelRequest.builder().id(identification).idShort(idShortofModel).semanticId(semanticId)
+				.endpoints(endpoints).build();
 	}
-	
+
 	@SneakyThrows
-	public CreateSubModelRequest getCreateSubModelRequestForChild(String shellId, String sematicId, String idShortofModel, String identification) {
-		
-		SemanticId semanticId = SemanticId.builder()
-				.type(CommonConstants.EXTERNAL_REFERENCE)
-				.keys(List.of(new Keys(CommonConstants.GLOBAL_REFERENCE,sematicId)))
-				.build();
+	public CreateSubModelRequest getCreateSubModelRequestForChild(String shellId, String sematicId,
+			String idShortofModel, String identification) {
+
+		SemanticId semanticId = SemanticId.builder().type(CommonConstants.EXTERNAL_REFERENCE)
+				.keys(List.of(new Keys(CommonConstants.GLOBAL_REFERENCE, sematicId))).build();
 
 		List<Endpoint> endpoints = prepareDtEndpoint(shellId, identification);
 
-		return CreateSubModelRequest.builder()
-				.idShort(idShortofModel)
-				.id(identification)
-				.semanticId(semanticId)
-				.endpoints(endpoints)
-				.build();
+		return CreateSubModelRequest.builder().idShort(idShortofModel).id(identification).semanticId(semanticId)
+				.endpoints(endpoints).build();
 	}
 
 	public List<Endpoint> prepareDtEndpoint(String shellId, String submodelIdentification) {
 		List<Endpoint> endpoints = new ArrayList<>();
-		endpoints.add(Endpoint.builder()
-				.endpointInterface(CommonConstants.INTERFACE)
+		endpoints.add(Endpoint.builder().endpointInterface(CommonConstants.INTERFACE)
 				.protocolInformation(ProtocolInformation.builder()
-						.endpointAddress(edcEndpoint + "/api/public/" + encodedUrl("shells/"+shellId+ "/submodels/"+submodelIdentification)
-								+ CommonConstants.SUBMODEL_CONTEXT_URL)
+						.endpointAddress(edcEndpoint + CommonConstants.SUBMODEL_CONTEXT_URL)
 						.endpointProtocol(CommonConstants.HTTP)
 						.endpointProtocolVersion(List.of(CommonConstants.ENDPOINT_PROTOCOL_VERSION))
 						.subProtocol(CommonConstants.SUB_PROTOCOL)
+						.subprotocolBody(encodedUrl("id=" + shellId + "-" + submodelIdentification) + ";dspEndpoint="
+								+ edcEndpoint)
 						.subprotocolBodyEncoding(CommonConstants.BODY_ENCODING)
-						.build())
+						.securityAttributes(List.of(new SecurityAttributes("NONE", "NONE", "NONE"))).build())
 				.build());
 		return endpoints;
 	}
-	
-	private ArrayList<KeyValuePair> getSpecificAssetIds(Map<String, String> specificAssetIds) {
 
-		ArrayList<KeyValuePair> specificIdentifiers = new ArrayList<>();
+	@SneakyThrows
+	public List<Object> getSpecificAssetIds(Map<String, String> specificAssetIds, List<String> bpns) {
 
-		specificAssetIds.entrySet().stream()
-				.forEach(entry -> specificIdentifiers.add(new KeyValuePair(entry.getKey(), entry.getValue())));
+		List<Object> specificIdentifiers = new ArrayList<>();
+		
+		List<Keys> keyList = bpnKeyRefrence(bpns);
+		
+		specificAssetIds.entrySet().stream().forEach(entry -> {
+
+			List<String> list = publicReadableSpecificAssetIDs.get(entry.getKey());
+			ExternalSubjectId externalSubjectId = null;
+
+			if (list != null && (list.contains("*") || list.contains(entry.getValue()))) {
+				externalSubjectId = ExternalSubjectId.builder()
+						.type("ExternalReference")
+						.keys(List.of(Keys.builder().type("GlobalReference").value(PUBLIC_READABLE).build()))
+						.build();
+				specificIdentifiers.add(new KeyValuePair(entry.getKey(), entry.getValue(), externalSubjectId));
+			}
+			else {
+				if (keyList != null && !keyList.isEmpty()) {
+					
+					externalSubjectId = ExternalSubjectId.builder()
+							.type("ExternalReference").keys(keyList)
+							.build();
+					specificIdentifiers.add(new KeyValuePair(entry.getKey(), entry.getValue(), externalSubjectId));
+
+				} else {
+					Map<String, Object> map = new HashMap<>();
+					map.put("name", entry.getKey());
+					map.put("value", entry.getValue());
+					specificIdentifiers.add(map);
+				}
+			}
+		});
+
 		return specificIdentifiers;
+	}
+
+	private List<Keys> bpnKeyRefrence(List<String> bpns) {
+		if (bpns != null && !(bpns.size() == 1 && bpns.contains(manufacturerId))) {
+			return bpns.stream()
+					.map(bpn -> Keys.builder().type("GlobalReference").value(bpn).build())
+					.toList();
+		}
+		return Collections.emptyList();
 	}
 
 	private String encodedUrl(String format) {
@@ -140,6 +181,18 @@ public class DigitalTwinsUtility {
 			return jnode.get(fieldName).asText();
 		else
 			return "";
+	}
+
+	@SneakyThrows
+	private List<String> getFieldFromJsonNodeArray(JsonNode jsonNode, String fieldName) {
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		if (jsonNode.get(fieldName) != null)
+			return objectMapper.readValue(jsonNode.get(fieldName).toString(), new TypeReference<List<String>>() {
+			});
+
+		else
+			return List.of();
 	}
 
 }

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/gateways/external/DigitalTwinsFeignClient.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/gateways/external/DigitalTwinsFeignClient.java
@@ -21,6 +21,7 @@
 package org.eclipse.tractusx.sde.digitaltwins.gateways.external;
 
 import java.net.URI;
+import java.util.List;
 
 import org.eclipse.tractusx.sde.common.model.KeycloakJWTTokenResponse;
 import org.eclipse.tractusx.sde.digitaltwins.entities.request.CreateSubModelRequest;
@@ -36,6 +37,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(value = "DigitalTwinsFeignClient", url = "placeholder", configuration = DigitalTwinsFeignClientConfiguration.class)
@@ -44,29 +46,40 @@ public interface DigitalTwinsFeignClient {
 	@PostMapping
 	KeycloakJWTTokenResponse readAuthToken(URI url, @RequestBody MultiValueMap<String, Object> body);
 
-	@DeleteMapping(path = "/shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}")
-	ResponseEntity<Object> deleteSubmodelfromShellById(URI url, @PathVariable("aasIdentifier") String shellId,
-			@PathVariable("submodelIdentifier") String submodelIdentifier);
-
 	@PostMapping(path = "/shell-descriptors")
 	ResponseEntity<ShellDescriptorResponse> createShellDescriptor(URI url, @RequestBody ShellDescriptorRequest request);
 
+	
 	@GetMapping(path = "/shell-descriptors/{aasIdentifier}")
 	ResponseEntity<ShellDescriptorResponse> getShellDescriptorByShellId(URI url,
-			@PathVariable("aasIdentifier") String shellId);
+			@PathVariable("aasIdentifier") String shellId, @RequestHeader("Edc-Bpn") String edcBpn);
+	
+	@DeleteMapping(path = "/shell-descriptors/{aasIdentifier}")
+	ResponseEntity<Void> deleteShell(URI url, @PathVariable("assetIds") String shellId);
 
 	@PostMapping(path = "/shell-descriptors/{aasIdentifier}/submodel-descriptors")
 	ResponseEntity<String> createSubModel(URI url, @PathVariable("aasIdentifier") String shellId,
 			@RequestBody CreateSubModelRequest request);
-
+	
 	@GetMapping(path = "/shell-descriptors/{aasIdentifier}/submodel-descriptors")
 	ResponseEntity<SubModelListResponse> getSubModels(URI digitalTwinsHost,
 			@PathVariable("aasIdentifier") String shellId);
 
-	@GetMapping(path = "/lookup/shells")
-	ResponseEntity<ShellLookupResponse> shellLookup(URI url, @RequestParam String assetIds);
+	@DeleteMapping(path = "/shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}")
+	ResponseEntity<Object> deleteSubmodelfromShellById(URI url, @PathVariable("aasIdentifier") String shellId,
+			@PathVariable("submodelIdentifier") String submodelIdentifier);
 
+	@GetMapping(path = "/lookup/shells")
+	ResponseEntity<ShellLookupResponse> shellLookup(URI url, @RequestParam String assetIds,
+			@RequestHeader("Edc-Bpn") String edcBpn);
+	
+	@PostMapping(path = "/lookup/shells/{assetIds}")
+	ResponseEntity<List<Object>> createShellSpecificAttributes(URI url, @PathVariable("assetIds") String shellId,
+			@RequestHeader("Edc-Bpn") String edcBpn, @RequestBody List<Object> specificAssetIds);
+	
 	@DeleteMapping(path = "/lookup/shells/{assetIds}")
-	ResponseEntity<Void> deleteShell(URI url, @PathVariable("assetIds") String shellId);
+	ResponseEntity<Void> deleteShellSpecificAttributes(URI url, @PathVariable("assetIds") String shellId,
+			@RequestHeader("Edc-Bpn") String edcBpn);
+
 
 }

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/entities/request/asset/DataAddressRequest.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/entities/request/asset/DataAddressRequest.java
@@ -38,7 +38,7 @@ import lombok.SneakyThrows;
 public class DataAddressRequest {
 
 	@Builder.Default
-	private String type = "HttpProxy";
+	private String type = "HttpData";
 
 	private HashMap<String, String> properties;
 

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/entities/request/policies/PolicyConstraintBuilderService.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/entities/request/policies/PolicyConstraintBuilderService.java
@@ -53,41 +53,45 @@ public class PolicyConstraintBuilderService {
 		if (usagePolicies != null && !usagePolicies.isEmpty()) {
 			usagePolicies.stream().forEach(policy -> usagePolicy(usageConstraintList, policy));
 		}
-		ActionRequest action = ActionRequest.builder().build();
-		action.addProperty("@type", "LogicalConstraint");
-		action.addProperty("odrl:and", usageConstraintList);
-		return action;
+		
+		if (!usageConstraintList.isEmpty()) {
+			ActionRequest action = ActionRequest.builder().build();
+			action.addProperty("@type", "LogicalConstraint");
+			action.addProperty("odrl:and", usageConstraintList);
+			return action;
+		}
+		return null;
 
 	}
 
 	private void usagePolicy(List<ConstraintRequest> usageConstraintList, UsagePolicies policy) {
+		ConstraintRequest request = null;
+
 		switch (policy.getType()) {
 		case DURATION:
-			ConstraintRequest request = DurationPolicyDTO.fromUsagePolicy(policy).toConstraint();
-			if (request != null) {
-				usageConstraintList.add(request);
-			}
+			request = DurationPolicyDTO.fromUsagePolicy(policy).toConstraint();
 			break;
 		case PURPOSE:
-			ConstraintRequest purposeRequest = PurposePolicyDTO.fromUsagePolicy(policy).toConstraint();
-			if (purposeRequest != null) {
-				usageConstraintList.add(purposeRequest);
-			}
+			request = PurposePolicyDTO.fromUsagePolicy(policy).toConstraint();
 			break;
 		case ROLE:
-			ConstraintRequest roleRequest = RolePolicyDTO.fromUsagePolicy(policy).toConstraint();
-			if (roleRequest != null) {
-				usageConstraintList.add(roleRequest);
-			}
+			request = RolePolicyDTO.fromUsagePolicy(policy).toConstraint();
 			break;
 		default:
 			break;
 		}
-	}
 
+		if (request != null) {
+			usageConstraintList.add(request);
+		}
+	}
+	
 	public ConstraintRequest toTraceabilityConstraint() {
 		String operator = "odrl:eq";
-		return ConstraintRequest.builder().leftOperand("FrameworkAgreement.traceability")
-				.operator(Operator.builder().id(operator).build()).rightOperand("active").build();
+		return ConstraintRequest.builder()
+				.leftOperand("FrameworkAgreement.traceability")
+				.operator(Operator.builder().id(operator).build())
+				.rightOperand("active")
+				.build();
 	}
 }

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/facilitator/CreateEDCAssetFacilator.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/facilitator/CreateEDCAssetFacilator.java
@@ -59,26 +59,24 @@ public class CreateEDCAssetFacilator extends AbstractEDCStepsHelper {
 
 		String assetId = assetEntryRequest.getAsset().getId();
 
-		ActionRequest usageAction = policyConstraintBuilderService.getUsagePolicyConstraints(usagePolicies);
+		
 		ActionRequest accessAction = policyConstraintBuilderService.getAccessConstraints(bpns);
 
 		String customValue = getCustomValue(usagePolicies);
 		if (StringUtils.isNotBlank(getCustomValue(usagePolicies))) {
 			extensibleProperties.put(UsagePolicyEnum.CUSTOM.name(), customValue);
 		}
-
+		
 		PolicyDefinitionRequest accessPolicyDefinitionRequest = policyFactory.getPolicy(assetId, accessAction,
 				new HashMap<>());
 		edcGateway.createPolicyDefinition(accessPolicyDefinitionRequest);
 		String accessPolicyId = accessPolicyDefinitionRequest.getId();
-		String usagePolicyId = accessPolicyDefinitionRequest.getId();
 
-		if (usageAction != null) {
-			PolicyDefinitionRequest usagePolicyDefinitionRequest = policyFactory.getPolicy(assetId, usageAction,
-					extensibleProperties);
-			edcGateway.createPolicyDefinition(usagePolicyDefinitionRequest);
-			usagePolicyId = usagePolicyDefinitionRequest.getId();
-		}
+		ActionRequest usageAction = policyConstraintBuilderService.getUsagePolicyConstraints(usagePolicies);
+		PolicyDefinitionRequest usagePolicyDefinitionRequest = policyFactory.getPolicy(assetId, usageAction,
+				extensibleProperties);
+		edcGateway.createPolicyDefinition(usagePolicyDefinitionRequest);
+		String usagePolicyId = usagePolicyDefinitionRequest.getId();
 
 		ContractDefinitionRequest contractDefinitionRequest = contractFactory.getContractDefinitionRequest(assetId,
 				accessPolicyId, usagePolicyId);

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/model/policies/PolicyDefinition.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/model/policies/PolicyDefinition.java
@@ -23,8 +23,6 @@ package org.eclipse.tractusx.sde.edc.model.policies;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.tractusx.sde.edc.entities.request.policies.PermissionRequest;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -49,7 +47,7 @@ public class PolicyDefinition {
 	private String id;
 	
 	@JsonProperty("odrl:permission")
-    private PermissionRequest permissions;
+    private Object permissions;
 	
 	@JsonProperty("odrl:prohibition")
     private List<Prohibition> prohibitions;

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/UtilityFunctions.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/UtilityFunctions.java
@@ -20,7 +20,6 @@
 
 package org.eclipse.tractusx.sde.edc.util;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -97,8 +96,7 @@ public class UtilityFunctions {
 		return policyResponse;
 	}
 
-	public static List<UsagePolicies> getUsagePolicies(List<ConstraintRequest> constraints) {
-		List<UsagePolicies> usagePolicies = new ArrayList<>();
+	public static List<UsagePolicies> getUsagePolicies(List<UsagePolicies> usagePolicies, List<ConstraintRequest> constraints) {
 		constraints.forEach(constraint -> {
 			String leftExpVal = constraint.getLeftOperand();
 			String rightExpVal = constraint.getRightOperand().toString();

--- a/modules/sde-submodules/assembly-part-relationship/src/main/java/org/eclipse/tractusx/sde/submodels/apr/steps/DigitalTwinsAspectRelationShipCsvHandlerUseCase.java
+++ b/modules/sde-submodules/assembly-part-relationship/src/main/java/org/eclipse/tractusx/sde/submodels/apr/steps/DigitalTwinsAspectRelationShipCsvHandlerUseCase.java
@@ -195,7 +195,7 @@ public class DigitalTwinsAspectRelationShipCsvHandlerUseCase extends Step {
 
 		for (String ddtUrl : dtURls) {
 
-			List<String> childshellIds = digitalTwinfacilitaor.shellLookupFromDDTR(shellLookupRequest, ddtUrl);
+			List<String> childshellIds = digitalTwinfacilitaor.shellLookupFromDDTR(shellLookupRequest, ddtUrl, aspectRelationShip.getChildManufacturerId());
 
 			if (childshellIds.isEmpty()) {
 				log.warn(aspectRelationShip.getRowNumber() + ", " + ddtUrl + ", No child aspect found for "
@@ -209,8 +209,11 @@ public class DigitalTwinsAspectRelationShipCsvHandlerUseCase extends Step {
 
 			if (childshellIds.size() == 1) {
 				ShellDescriptorResponse shellDescriptorResponse = digitalTwinfacilitaor
-						.getShellDetailsById(childshellIds.get(0), ddtUrl);
+						.getShellDetailsById(childshellIds.get(0), ddtUrl, aspectRelationShip.getChildManufacturerId());
 				childUUID = shellDescriptorResponse.getGlobalAssetId();
+				log.debug(aspectRelationShip.getRowNumber() + ", " + ddtUrl + ", Child aspect found for "
+						+ shellLookupRequest.toJsonString());
+				break;
 			}
 
 		}

--- a/modules/sde-submodules/batch/batch.md
+++ b/modules/sde-submodules/batch/batch.md
@@ -5,9 +5,9 @@
 This module use for Batch submodel specification and descriptors. It's contain the codes related to Batch to validate, parse and transfer data for DigitalTwins and EDC to create aspect twins and data offer.
 
 ---
-#### Version: 1.0.2
-#### Batch Aspect Model URN: urn:bamm:io.catenax.batch:1.0.2#Batch
-#### Semantic Id: urn:bamm:io.catenax.batch:1.0.2
+#### Version: 2.0.0
+#### Batch Aspect Model URN: urn:bamm:io.catenax.batch:2.0.0#Batch
+#### Semantic Id: urn:samm:io.catenax.batch:2.0.0
 ---
 
 ### Schema
@@ -27,10 +27,8 @@ Please find below links for schema details:
 | manufacturing_date    			| Yes 							    | 	 4	   	|
 | manufacturing_country  	    	| No                            	| 	 5	  	|
 | manufacturer_part_id 		      	| Yes                           	| 	 6	  	|
-| customer_part_id		    		| No                     		    | 	 7	 	|
-| classification		 			| Yes                               |    8 	 	|
-| name_at_manufacturer	 			| Yes                           	|    9 	 	|
-| name_at_customer	 				| No                           	    |    10 	|
+| classification		 			| Yes                               |    7	 	|
+| name_at_manufacturer	 			| Yes                           	|    8 	 	|
 
 
 #### [CSV Sample File Link]

--- a/modules/sde-submodules/batch/src/main/java/org/eclipse/tractusx/sde/submodels/batch/entity/BatchEntity.java
+++ b/modules/sde-submodules/batch/src/main/java/org/eclipse/tractusx/sde/submodels/batch/entity/BatchEntity.java
@@ -48,14 +48,10 @@ public class BatchEntity implements Serializable {
     private String manufacturingCountry;
     @Column(name = "manufacturer_part_id")
     private String manufacturerPartId;
-    @Column(name = "customer_part_id")
-    private String customerPartId;
     @Column(name = "classification")
     private String classification;
     @Column(name = "name_at_manufacturer")
     private String nameAtManufacturer;
-    @Column(name = "name_at_customer")
-    private String nameAtCustomer;
     @Column(name = "shell_id")
     private String shellId;
     @Column(name = "sub_model_id")

--- a/modules/sde-submodules/batch/src/main/java/org/eclipse/tractusx/sde/submodels/batch/mapper/BatchMapper.java
+++ b/modules/sde-submodules/batch/src/main/java/org/eclipse/tractusx/sde/submodels/batch/mapper/BatchMapper.java
@@ -81,10 +81,8 @@ public abstract class BatchMapper {
 
 		PartTypeInformation partTypeInformation = PartTypeInformation.builder()
 				.manufacturerPartId(entity.getManufacturerPartId())
-				.customerPartId(entity.getCustomerPartId())
 				.classification(entity.getClassification())
 				.nameAtManufacturer(entity.getNameAtManufacturer())
-				.nameAtCustomer(entity.getNameAtCustomer())
 				.build();
 
 		return new Gson().toJsonTree(SubmodelResultResponse.builder().localIdentifiers(localIdentifiers)

--- a/modules/sde-submodules/batch/src/main/java/org/eclipse/tractusx/sde/submodels/batch/steps/DigitalTwinsBatchCsvHandlerUseCase.java
+++ b/modules/sde-submodules/batch/src/main/java/org/eclipse/tractusx/sde/submodels/batch/steps/DigitalTwinsBatchCsvHandlerUseCase.java
@@ -80,6 +80,10 @@ public class DigitalTwinsBatchCsvHandlerUseCase extends Step {
 		} else if (shellIds.size() == 1) {
 			logDebug(String.format("Shell id found for '%s'", shellLookupRequest.toJsonString()));
 			shellId = shellIds.stream().findFirst().orElse(null);
+			
+			digitalTwinsFacilitator.updateShellSpecificAssetIdentifiers(shellId,
+					digitalTwinsUtility.getSpecificAssetIds(getSpecificAssetIds(batch), batch.getBpnNumbers()));
+			
 			logDebug(String.format("Shell id '%s'", shellId));
 		} else {
 			throw new CsvHandlerDigitalTwinUseCaseException(

--- a/modules/sde-submodules/batch/src/main/resources/batch.csv
+++ b/modules/sde-submodules/batch/src/main/resources/batch.csv
@@ -1,2 +1,2 @@
-uuid;batch_id;part_instance_id;manufacturing_date;manufacturing_country;manufacturer_part_id;customer_part_id;classification;name_at_manufacturer;name_at_customer;optional_identifier_key;optional_identifier_value
-urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1f8ff4c2;BIDNO345678;PIDNO678905;2022-02-05T14:48:54;HUR;122-0.740-3430-A;PRT-NO345;product;Mirror left;side element A;;
+uuid;batch_id;part_instance_id;manufacturing_date;manufacturing_country;manufacturer_part_id;classification;name_at_manufacturer;
+urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1f8ff4c2;BIDNO345678;PIDNO678905;2022-02-05T14:48:54;HUR;122-0.740-3430-A;product;Mirror left

--- a/modules/sde-submodules/batch/src/main/resources/batch.json
+++ b/modules/sde-submodules/batch/src/main/resources/batch.json
@@ -4,8 +4,8 @@
 	"type": "array",
 	"id": "batch",
 	"idShort": "Batch",
-	"version": "1.0.2",
-	"semantic_id": "urn:bamm:io.catenax.batch:1.0.2#Batch",
+	"version": "2.0.0",
+	"semantic_id": "urn:samm:io.catenax.batch:2.0.0#Batch",
 	"title": "Batch",
 	"shortDescription": "BoM AsBuilt - Submodel Batch",
 	"description": "A batch is a quantity of (semi-) finished products or (raw) material product that have been produced under the same circumstances (e.g. same production location), as specified groups or amounts, within a certain time frame. Every batch can differ in the number or amount of products. Different batches can have varied specifications, e.g., different colors. A batch is identified via a Batch ID.",
@@ -280,17 +280,6 @@
 					"37754B7-76"
 				]
 			},
-			"customer_part_id": {
-				"type": [
-					"string",
-					"null"
-				],
-				"title": "Customer Part ID",
-				"description": "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the customer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number or batch number. Note: This property may only be populated in case there is a single customer for the batch.",
-				"examples": [
-					"37754B7-76"
-				]
-			},
 			"classification": {
 				"type": [
 					"string"
@@ -319,17 +308,6 @@
 				"examples": [
 					"Sensor"
 				]
-			},
-			"name_at_customer": {
-				"type": [
-					"string",
-					"null"
-				],
-				"title": "Name At Customer",
-				"description": "Name of the part as assigned by the customer",
-				"examples": [
-					"Customer"
-				]
 			}
 		}
 	},
@@ -337,14 +315,12 @@
 		{
 			"uuid": "urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2",
 			"batch_id": "NO-159040131155901488695376",
-			"part_instance_id":"PINO-34634534535",
+			"part_instance_id": "PINO-34634534535",
 			"manufacturing_date": "2022-02-04T14:48:54.709Z",
 			"manufacturing_country": "DEU",
 			"manufacturer_part_id": "37754B7-76",
-			"customer_part_id": "37754B7-76",
 			"classification": "component",
-			"name_at_manufacturer": "Sensor",
-			"name_at_customer": "Sensor"
+			"name_at_manufacturer": "Sensor"
 		}
 	]
 }

--- a/modules/sde-submodules/part-as-planned/src/main/java/org/eclipse/tractusx/sde/submodels/pap/steps/DigitalTwinsPartAsPlannedHandlerStep.java
+++ b/modules/sde-submodules/part-as-planned/src/main/java/org/eclipse/tractusx/sde/submodels/pap/steps/DigitalTwinsPartAsPlannedHandlerStep.java
@@ -77,6 +77,10 @@ public class DigitalTwinsPartAsPlannedHandlerStep extends Step {
 		} else if (shellIds.size() == 1) {
 			logDebug(String.format("Shell id found for '%s'", shellLookupRequest.toJsonString()));
 			shellId = shellIds.stream().findFirst().orElse(null);
+			
+			digitalTwinsFacilitator.updateShellSpecificAssetIdentifiers(shellId,
+					digitalTwinsUtility.getSpecificAssetIds(getSpecificAssetIds(partAsPlannedAspect), partAsPlannedAspect.getBpnNumbers()));
+			
 			logDebug(String.format("Shell id '%s'", shellId));
 		} else {
 			throw new CsvHandlerDigitalTwinUseCaseException(

--- a/modules/sde-submodules/part-site-information-as-planned/src/main/java/org/eclipse/tractusx/sde/submodels/psiap/steps/DigitalTwinsPartSiteInformationAsPlannedHandlerStep.java
+++ b/modules/sde-submodules/part-site-information-as-planned/src/main/java/org/eclipse/tractusx/sde/submodels/psiap/steps/DigitalTwinsPartSiteInformationAsPlannedHandlerStep.java
@@ -80,6 +80,11 @@ public class DigitalTwinsPartSiteInformationAsPlannedHandlerStep extends Step {
 		} else if (shellIds.size() == 1) {
 			logDebug(String.format("Shell id found for '%s'", shellLookupRequest.toJsonString()));
 			shellId = shellIds.stream().findFirst().orElse(null);
+			
+			digitalTwinsFacilitator.updateShellSpecificAssetIdentifiers(shellId,
+					digitalTwinsUtility.getSpecificAssetIds(getSpecificAssetIds(partSiteInformationAsPlannedAspect),
+							partSiteInformationAsPlannedAspect.getBpnNumbers()));
+
 			logDebug(String.format("Shell id '%s'", shellId));
 		} else {
 			throw new CsvHandlerDigitalTwinUseCaseException(

--- a/modules/sde-submodules/serial-part-typization/src/main/java/org/eclipse/tractusx/sde/submodels/spt/steps/DigitalTwinsAspectCsvHandlerUseCase.java
+++ b/modules/sde-submodules/serial-part-typization/src/main/java/org/eclipse/tractusx/sde/submodels/spt/steps/DigitalTwinsAspectCsvHandlerUseCase.java
@@ -78,6 +78,8 @@ public class DigitalTwinsAspectCsvHandlerUseCase extends Step {
 		} else if (shellIds.size() == 1) {
 			logDebug(String.format("Shell id found for '%s'", shellLookupRequest.toJsonString()));
 			shellId = shellIds.stream().findFirst().orElse(null);
+			digitalTwinsFacilitator.updateShellSpecificAssetIdentifiers(shellId,
+					digitalTwinsUtility.getSpecificAssetIds(getSpecificAssetIds(aspect), aspect.getBpnNumbers()));
 			logDebug(String.format("Shell id '%s'", shellId));
 		} else {
 			throw new CsvHandlerDigitalTwinUseCaseException(

--- a/modules/sde-submodules/single-level-bom-as-planned/src/main/java/org/eclipse/tractusx/sde/submodels/slbap/steps/DigitalTwinsSingleLevelBoMAsPlannedHandlerStep.java
+++ b/modules/sde-submodules/single-level-bom-as-planned/src/main/java/org/eclipse/tractusx/sde/submodels/slbap/steps/DigitalTwinsSingleLevelBoMAsPlannedHandlerStep.java
@@ -80,6 +80,12 @@ public class DigitalTwinsSingleLevelBoMAsPlannedHandlerStep extends Step {
 		} else if (shellIds.size() == 1) {
 			logDebug(String.format("Shell id found for '%s'", shellLookupRequest.toJsonString()));
 			shellId = shellIds.stream().findFirst().orElse(null);
+			
+			digitalTwinsFacilitator.updateShellSpecificAssetIdentifiers(shellId,
+					digitalTwinsUtility.getSpecificAssetIds(
+							getSpecificAssetIdsForSingleLevel(singleLevelBoMAsPlannedAspect),
+							singleLevelBoMAsPlannedAspect.getBpnNumbers()));
+			
 			logDebug(String.format("Shell id '%s'", shellId));
 		} else {
 			throw new CsvHandlerDigitalTwinUseCaseException(
@@ -145,13 +151,21 @@ public class DigitalTwinsSingleLevelBoMAsPlannedHandlerStep extends Step {
 	}
 	
 	private ShellLookupRequest getShellLookupRequest(SingleLevelBoMAsPlanned singleLevelBoMAsPlannedAspect) {
+
 		ShellLookupRequest shellLookupRequest = new ShellLookupRequest();
-		shellLookupRequest.addLocalIdentifier(CommonConstants.ASSET_LIFECYCLE_PHASE, CommonConstants.AS_PLANNED);
-		shellLookupRequest.addLocalIdentifier(CommonConstants.MANUFACTURER_PART_ID,
-				singleLevelBoMAsPlannedAspect.getParentManufacturerPartId());
-		shellLookupRequest.addLocalIdentifier(CommonConstants.MANUFACTURER_ID, digitalTwinsUtility.getManufacturerId());
+		getSpecificAssetIdsForSingleLevel(singleLevelBoMAsPlannedAspect).entrySet().stream()
+				.forEach(entry -> shellLookupRequest.addLocalIdentifier(entry.getKey(), entry.getValue()));
 
 		return shellLookupRequest;
+	}
+	
+	private Map<String, String> getSpecificAssetIdsForSingleLevel(SingleLevelBoMAsPlanned singleLevelBoMAsPlannedAspect) {
+		Map<String, String> specificIdentifiers = new HashMap<>();
+		specificIdentifiers.put(CommonConstants.ASSET_LIFECYCLE_PHASE, CommonConstants.AS_PLANNED);
+		specificIdentifiers.put(CommonConstants.MANUFACTURER_PART_ID,
+				singleLevelBoMAsPlannedAspect.getParentManufacturerPartId());
+		specificIdentifiers.put(CommonConstants.MANUFACTURER_ID, digitalTwinsUtility.getManufacturerId());
+		return specificIdentifiers;
 	}
 
 	private ShellDescriptorRequest getShellDescriptorRequest(PartAsPlanned partAsPlannedAspect) {

--- a/modules/sde-submodules/single-level-usage-as-built/src/main/java/org/eclipse/tractusx/sde/submodels/sluab/steps/DigitalTwinsSingleLevelUsageAsBuiltCsvHandlerUseCase.java
+++ b/modules/sde-submodules/single-level-usage-as-built/src/main/java/org/eclipse/tractusx/sde/submodels/sluab/steps/DigitalTwinsSingleLevelUsageAsBuiltCsvHandlerUseCase.java
@@ -80,6 +80,12 @@ public class DigitalTwinsSingleLevelUsageAsBuiltCsvHandlerUseCase extends Step {
 		} else if (shellIds.size() == 1) {
 			logDebug(String.format("Shell id found for '%s'", shellLookupRequest.toJsonString()));
 			shellId = shellIds.stream().findFirst().orElse(null);
+			
+			digitalTwinsFacilitator.updateShellSpecificAssetIdentifiers(shellId,
+					digitalTwinsUtility.getSpecificAssetIds(
+							getSpecificAssetIdsForSingleLevel(aspectSingleLevelUsageAsBuilt),
+							aspectSingleLevelUsageAsBuilt.getBpnNumbers()));
+			
 			logDebug(String.format("Shell id '%s'", shellId));
 		} else {
 			throw new CsvHandlerDigitalTwinUseCaseException(
@@ -143,18 +149,29 @@ public class DigitalTwinsSingleLevelUsageAsBuiltCsvHandlerUseCase extends Step {
 
 	private ShellLookupRequest getShellLookupRequest(SingleLevelUsageAsBuilt aspectSingleLevelUsageAsBuilt) {
 		ShellLookupRequest shellLookupRequest = new ShellLookupRequest();
-		shellLookupRequest.addLocalIdentifier(CommonConstants.PART_INSTANCE_ID,
-				aspectSingleLevelUsageAsBuilt.getParentPartInstanceId());
-		shellLookupRequest.addLocalIdentifier(CommonConstants.MANUFACTURER_PART_ID,
-				aspectSingleLevelUsageAsBuilt.getParentManufacturerPartId());
-		shellLookupRequest.addLocalIdentifier(CommonConstants.MANUFACTURER_ID, digitalTwinsUtility.getManufacturerId());
 
-		if (aspectSingleLevelUsageAsBuilt.hasOptionalParentIdentifier()) {
-			shellLookupRequest.addLocalIdentifier(aspectSingleLevelUsageAsBuilt.getParentOptionalIdentifierKey(),
-					aspectSingleLevelUsageAsBuilt.getParentOptionalIdentifierValue());
-		}
+		getSpecificAssetIdsForSingleLevel(aspectSingleLevelUsageAsBuilt).entrySet().stream()
+				.forEach(entry -> shellLookupRequest.addLocalIdentifier(entry.getKey(), entry.getValue()));
 
 		return shellLookupRequest;
+	}
+
+	private Map<String, String> getSpecificAssetIdsForSingleLevel(
+			SingleLevelUsageAsBuilt aspectSingleLevelUsageAsBuilt) {
+
+		Map<String, String> specificIdentifiers = new HashMap<>();
+
+		specificIdentifiers.put(CommonConstants.PART_INSTANCE_ID,
+				aspectSingleLevelUsageAsBuilt.getParentPartInstanceId());
+		specificIdentifiers.put(CommonConstants.MANUFACTURER_PART_ID,
+				aspectSingleLevelUsageAsBuilt.getParentManufacturerPartId());
+		specificIdentifiers.put(CommonConstants.MANUFACTURER_ID, digitalTwinsUtility.getManufacturerId());
+
+		if (aspectSingleLevelUsageAsBuilt.hasOptionalParentIdentifier()) {
+			specificIdentifiers.put(aspectSingleLevelUsageAsBuilt.getParentOptionalIdentifierKey(),
+					aspectSingleLevelUsageAsBuilt.getParentOptionalIdentifierValue());
+		}
+		return specificIdentifiers;
 	}
 	
 	private Map<String, String> getSpecificAssetIds(Aspect aspect) {

--- a/modules/sde-submodules/submodules.md
+++ b/modules/sde-submodules/submodules.md
@@ -9,7 +9,7 @@ Currently SDE supports below submodels.
 ### Supported Models
 
 #### [serial-part-typization in Version 1.1.1]
-#### [batch in Version 1.0.2]
+#### [batch in Version 2.0.0]
 #### [assembly-part-relationship in Version 1.1.1]
 #### [partAsPlanned in Version 1.0.0]
 #### [singleLevelBoMAsPlanned in Version 1.0.1]
@@ -36,7 +36,7 @@ Once your maven module ready just do the clean build and install so submodel wil
 
 
 [serial-part-typization in Version 1.1.1]: serial-part-typization/serial-part-typization.md
-[batch in Version 1.0.2]: batch/batch.md
+[batch in Version 2.0.0]: batch/batch.md
 [assembly-part-relationship in Version 1.1.1]: assembly-part-relationship/assembly-part-relationship.md
 [partAsPlanned in Version 1.0.0]: part-as-planned/part-as-planned.md
 [singleLevelBoMAsPlanned in Version 1.0.1]: single-level-bom-as-planned/single-level-bom-as-planned.md


### PR DESCRIPTION
## Description
- Added external subject in specific asset Ids.
- Update AAS submodel endpoints subprotocolBody.
- Supported Batch submodel version 2.0.0.
- DDTR update with latest version.
- Feign Client changes updated for child aspect relationship.
-  Change log updated.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
