### PR TITLE
[fix|sde-backend] Veracode security fix CVE-2023-33202 and docker command updated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - docker cmd updated,removed r from run command.
 - fixed veracode security CVE-2023-33202(Bouncy Castle Denial of Service). 
-- 
-## [Unreleased]
 - Updated assembly-part-relationship csv and .md file
 
 ## [2.3.0] - 2023-11-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - docker cmd updated,removed r from run command.
 - fixed veracode security CVE-2023-33202(Bouncy Castle Denial of Service). 
-- Updated assembly-part-relationship csv and .md file
+- Updated assembly-part-relationship csv and .md file.
 
 ## [2.3.0] - 2023-11-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [2.3.1] - 2023-11-29
+### Fixed
+- docker cmd updated,removed r from run command.
+- fixed veracode security CVE-2023-33202(Bouncy Castle Denial of Service). 
+
 ## [2.3.0] - 2023-11-29
 ### Added
 - DT use refactor for look up twin.
@@ -242,7 +247,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Compliance with Catena-X Guidelines
 - Integration with Digital Twin registry service.
 
-[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.0...main
+[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.1...main
+[2.3.1]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.1.0...v2.1.1

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -55,11 +55,9 @@ maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.8, Apache-2.0 
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.8, Apache-2.0, approved, #6997
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.8, Apache-2.0, approved, #7920
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.aspectj/aspectjweaver/1.9.19, EPL-1.0, approved, tools.aspectj
+maven/mavencentral/org.aspectj/aspectjweaver/1.9.19, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
-maven/mavencentral/org.bouncycastle/bcpkix-jdk15on/1.69, MIT, approved, clearlydefined
-maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.69, MIT, approved, clearlydefined
-maven/mavencentral/org.bouncycastle/bcutil-jdk15on/1.69, MIT, approved, clearlydefined
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.checkerframework/checker-qual/3.33.0, MIT, approved, clearlydefined
 maven/mavencentral/org.eclipse.angus/angus-activation/2.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.persistence/eclipselink/3.0.3, EPL-2.0 OR BSD-3-Clause, approved, ee4j.eclipselink

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -43,7 +43,7 @@ RUN useradd -m -d /home/sdeuser -s /bin/bash -u $USER_UID -U $USERNAME
 USER $USERNAME
 
 # set deployment directory
-WORKDIR /home/user/sdeuser/sdeapp
+WORKDIR /home/sdeuser/sdeapp
 COPY LICENSE NOTICE.md DEPENDENCIES SECURITY.md  ./
 
 # copy over the built artifact from the maven image

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -39,21 +39,16 @@ ARG USER_GID=$USER_UID
 
 # Create the user
 
-RUN useradd -rm -d /home/sdeuser -s /bin/bash -u $USER_UID -U $USERNAME 
-
-
+RUN useradd -m -d /home/sdeuser -s /bin/bash -u $USER_UID -U $USERNAME 
 USER $USERNAME
 
 # set deployment directory
 WORKDIR /home/user/sdeuser/sdeapp
-
 COPY LICENSE NOTICE.md DEPENDENCIES SECURITY.md  ./
 
 # copy over the built artifact from the maven image
-
 COPY --from=build modules/sde-core/target/*.jar ./app.jar
-
 EXPOSE 8080
-# set the startup command to run your binary
 
+# set the startup command to run your binary
 CMD ["java", "-jar", "./app.jar","--spring.config.location=file:/app/configuration.properties"]

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,16 @@
 					<groupId>commons-fileupload</groupId>
 					<artifactId>commons-fileupload</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcpkix-jdk15on</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk18on</artifactId>
+			<version>1.77</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Description
- docker cmd updated,removed r from run command.
- fixed veracode security CVE-2023-33202(Bouncy Castle Denial of Service). 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
