### PR TITLE
Fixed Veracode security CVE-2023-46589 and CVE-2023-34053

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [Unreleased] 
+### Fixed
+- fixed veracode security in app CVE-2023-46589 and CVE-2023-34053 .
+
 ## [2.3.2] - 2023-12-01
 ### Fixed
 - fixed veracode security CVE-2023-6378(logback-classic Denial Of Service)

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -51,9 +51,10 @@ maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.17.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.17.1, Apache-2.0, approved, #2163
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.8, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.16, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.8, Apache-2.0, approved, #6997
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.8, Apache-2.0, approved, #7920
+maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/10.1.8, Apache-2.0, approved, #8196
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.aspectj/aspectjweaver/1.9.19, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
@@ -148,7 +149,7 @@ maven/mavencentral/org.springframework/spring-jdbc/6.0.9, Apache-2.0, approved, 
 maven/mavencentral/org.springframework/spring-orm/6.0.9, Apache-2.0, approved, #5925
 maven/mavencentral/org.springframework/spring-test/6.0.9, Apache-2.0, approved, #7003
 maven/mavencentral/org.springframework/spring-tx/6.0.9, Apache-2.0, approved, #5926
-maven/mavencentral/org.springframework/spring-web/6.0.9, Apache-2.0, approved, #5942
+maven/mavencentral/org.springframework/spring-web/6.0.14, Apache-2.0, approved, #5942
 maven/mavencentral/org.springframework/spring-webmvc/6.0.9, Apache-2.0, approved, #5944
 maven/mavencentral/org.webjars/swagger-ui/4.15.5, Apache-2.0 AND MIT, approved, #5921
 maven/mavencentral/org.webjars/webjars-locator-core/0.52, MIT, approved, clearlydefined

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,25 @@
 					<groupId>ch.qos.logback</groupId>
 					<artifactId>logback-classic</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.tomcat.embed</groupId>
+					<artifactId>tomcat-embed-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-web</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<version>10.1.16</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>6.0.14</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
## Description
- Fixed Veracode security CVE-2023-46589(tomcat-embed-core) and CVE-2023-34053(spring-web): 
Excluded tomcat-embed-core and newer version
reason: org.apache.tomcat: tomcat-catalina(10.1.18) is vulnerable to Request Smuggling

Excluded spring-web old versions and added newer version
reason: org.springframework: spring-web (6.0.9) is vulnerable to Denial Of Service (DoS)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
