### PR TITLE
[fix|sde-backend] : Fixed Vulnerability logback issue of CVE-2023-6481 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [2.3.4] - 2023-12-21
+## [Unreleased] - 2023-02-05
 
+### Added
+
+- New changes for dDTR support.
+- Fixed Vulnerability logback issue of CVE-2023-6481.
+
+## [2.3.4] - 2023-12-21
 ### Fixed
 - Removed time duration from policy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - 2023-02-05
 
-### Added
+### Fixed
 
 - Fix new dDTR support changes.
 - Fixed Vulnerability logback issue of CVE-2023-6481.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- New changes for dDTR support.
+- Fix new dDTR support changes.
 - Fixed Vulnerability logback issue of CVE-2023-6481.
 
 ## [2.3.4] - 2023-12-21

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,6 +1,8 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.13, EPL-1.0 OR LGPL-2.1-only, approved, #3435
+maven/mavencentral/ch.qos.logback/logback-classic/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3435
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3435
 maven/mavencentral/ch.qos.logback/logback-core/1.4.13, EPL-1.0 OR LGPL-2.1-only, approved, #3373
+maven/mavencentral/ch.qos.logback/logback-core/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/ch.qos.logback/logback-core/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.ethlo.time/itu/1.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.0, Apache-2.0, approved, #7947

--- a/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/facilitator/DigitalTwinsFacilitator.java
+++ b/modules/sde-external-services/digital-twins/src/main/java/org/eclipse/tractusx/sde/digitaltwins/facilitator/DigitalTwinsFacilitator.java
@@ -57,7 +57,7 @@ public class DigitalTwinsFacilitator {
 
 		List<String> shellIds = List.of();
 		try {
-			ResponseEntity<ShellLookupResponse> response = digitalTwinsFeignClient.shellLookup(request.toJsonString(),
+			ResponseEntity<ShellLookupResponse> response = digitalTwinsFeignClient.shellLookup(encodeShellIdBase64Utf8(request.toJsonString()),
 					manufacturerId);
 
 			ShellLookupResponse body = response.getBody();

--- a/modules/sde-submodules/assembly-part-relationship/src/main/java/org/eclipse/tractusx/sde/submodels/apr/steps/DigitalTwinsAspectRelationShipCsvHandlerUseCase.java
+++ b/modules/sde-submodules/assembly-part-relationship/src/main/java/org/eclipse/tractusx/sde/submodels/apr/steps/DigitalTwinsAspectRelationShipCsvHandlerUseCase.java
@@ -250,7 +250,7 @@ public class DigitalTwinsAspectRelationShipCsvHandlerUseCase extends Step {
 			Map<String, String> header = Map.of(edrToken.getAuthKey(), edrToken.getAuthCode());
 
 			ResponseEntity<ShellLookupResponse> shellLookup = eDCDigitalTwinProxyForLookUp
-					.shellLookup(new URI(endpoint), shellLookupRequest.toJsonString(), header);
+					.shellLookup(new URI(endpoint),encodeShellIdBase64Utf8(shellLookupRequest.toJsonString()), header);
 			ShellLookupResponse body = shellLookup.getBody();
 
 			if (shellLookup.getStatusCode() == HttpStatus.OK && body != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.4.13</version>
+			<version>1.4.14</version>
 			<exclusions>
 				<exclusion>
 					<groupId>ch.qos.logback</groupId>
@@ -138,7 +138,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
-			<version>1.4.13</version>
+			<version>1.4.14</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
### Fixed
- Fix new dDTR support changes.
- Fixed Vulnerability logback issue of CVE-2023-6481.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
