### PR TITLE
[feat|sde-backend] : Policy-hub Proxy controller and Policy pojo added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [Unreleased] - 2023-02-06
+## [Unreleased] - 2023-02-10
 
 ### Added
 
 - Policy-Hub service api integration.
+- Added New Policy Entities and pojo classes.
 
 ### Fixed
 

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/CommonPropEntity.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/CommonPropEntity.java
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
+import lombok.Data;
+
+@Data
+@MappedSuperclass
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommonPropEntity {
+
+	@Transient
+	@JsonProperty(value = "row_number")
+	private Integer rowNumber;
+
+	@Column(name = "process_id")
+	@JsonProperty(value = "process_id")
+	private String processId;
+
+	@Column(name = "shell_id")
+	@JsonProperty(value = "shell_id")
+	private String shellId;
+
+	@Column(name = "sub_model_id")
+	@JsonProperty(value = "sub_model_id")
+	private String subModelId;
+
+	@Column(name = "usage_policy_id")
+	@JsonProperty(value = "usage_policy_id")
+	private String usagePolicyId;
+
+	@Column(name = "asset_id")
+	@JsonProperty(value = "asset_id")
+	private String assetId;
+
+	@Column(name = "access_policy_id")
+	@JsonProperty(value = "access_policy_id")
+	private String accessPolicyId;
+
+	@Column(name = "contract_defination_id")
+	@JsonProperty(value = "contract_defination_id")
+	private String contractDefinationId;
+
+	@Column(name = "deleted")
+	@JsonProperty(value = "deleted")
+	private String deleted;
+
+	@Column(name = "updated")
+	@JsonProperty(value = "updated")
+	private String updated;
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/Policies.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/Policies.java
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.common.entities;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class Policies {
+	
+	private String technicalKey;
+	private List<String> value;
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyModel.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyModel.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
- * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyModel.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyModel.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyModel.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyModel.java
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2023 T-Systems International GmbH
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.entities;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class PolicyModel {
+
+	private String uuid;
+
+	@JsonProperty(value = "policy_name")
+	private String policyName;
+
+	@JsonProperty(value = "access_policies")
+	private List<Policies> accessPolicies;
+	
+	@JsonProperty(value = "usage_policies")
+	private List<Policies> usagePolicies;
+
+	private LocalDateTime lastUpdatedTime;
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyTemplateRequest.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyTemplateRequest.java
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
+public class PolicyTemplateRequest extends PolicyModel {
+
+	@Builder.Default
+	private PolicyTemplateType type = PolicyTemplateType.NONE;
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyTemplateType.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/PolicyTemplateType.java
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.entities;
+
+public enum PolicyTemplateType {
+	NONE, EXISTING, NEW
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/SubmodelJsonReq.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/SubmodelJsonReq.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/SubmodelJsonReq.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/entities/SubmodelJsonReq.java
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2023 T-Systems International GmbH
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.entities;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
+public class SubmodelJsonReq extends PolicyTemplateRequest {
+
+	@NotEmpty
+	@JsonProperty(value = "row_data")
+	private List<ObjectNode> rowData;
+	
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/enums/ProgressStatusEnum.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/enums/ProgressStatusEnum.java
@@ -1,8 +1,8 @@
 /********************************************************************************
  * Copyright (c) 2022 Critical TechWorks GmbH
  * Copyright (c) 2022 BMW GmbH
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/enums/ProgressStatusEnum.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/enums/ProgressStatusEnum.java
@@ -25,5 +25,6 @@ package org.eclipse.tractusx.sde.common.enums;
 public enum ProgressStatusEnum {
     IN_PROGRESS,
     COMPLETED,
-    FAILED
+    FAILED,
+    PARTIALLY_FAILED
 }

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/enums/ProgressStatusEnum.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/enums/ProgressStatusEnum.java
@@ -1,8 +1,8 @@
 /********************************************************************************
  * Copyright (c) 2022 Critical TechWorks GmbH
  * Copyright (c) 2022 BMW GmbH
- * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
- * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/GlobalDefaultExceptionHandler.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/GlobalDefaultExceptionHandler.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/GlobalDefaultExceptionHandler.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/GlobalDefaultExceptionHandler.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
- * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/GlobalDefaultExceptionHandler.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/GlobalDefaultExceptionHandler.java
@@ -27,6 +27,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -90,7 +91,7 @@ public class GlobalDefaultExceptionHandler extends ResponseEntityExceptionHandle
 			log.error("FeignException JsonProcessingException " + e.getMessage());
 		}
 
-		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+		return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(ex.status()));
 	}
 
 	@ExceptionHandler(ConstraintViolationException.class)
@@ -111,7 +112,16 @@ public class GlobalDefaultExceptionHandler extends ResponseEntityExceptionHandle
 			errors.put(fieldName, errorMessage);
 		});
 		log.error("MethodArgumentNotValidException " + errors);
-		return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+		Map<String, String> errorResponse = prepareErrorResponse(errors.toString());
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
+			HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+		log.error("HandleHttpMessageNotReadable " + ex.getMessage());
+		Map<String, String> errorResponse = prepareErrorResponse(ex.getMessage());
+		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(AccessDeniedException.class)

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/ServiceException.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/ServiceException.java
@@ -32,6 +32,6 @@ public class ServiceException extends Exception {
 
 	public ServiceException(String exceptionstr) {
 		super(exceptionstr);
-		log.debug(exceptionstr);
+		log.info(exceptionstr);
 	}
 }

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/ServiceException.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/ServiceException.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/ServiceException.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/exception/ServiceException.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
- * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/mapper/AspectResponseFactory.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/mapper/AspectResponseFactory.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import lombok.SneakyThrows;
+
+@Component
+public class AspectResponseFactory {
+
+	ObjectMapper mapper = new ObjectMapper();
+
+	@SneakyThrows
+	public JsonObject maptoReponse(Object csvObject, Object aspectObject) {
+		JsonObject jobj = new JsonObject();
+		jobj.add("csv", extracted(csvObject));
+		jobj.add("json", new Gson().toJsonTree(aspectObject).getAsJsonObject());
+
+		return jobj;
+	}
+
+	private JsonObject extracted(Object csvObject) throws JsonProcessingException {
+		String writeValueAsString = mapper.writeValueAsString(csvObject);
+		writeValueAsString = writeValueAsString.replace(":null", ": \"\"");
+		return new Gson().fromJson(writeValueAsString, JsonObject.class);
+	}
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/mapper/PolicyTemplateObjectMapper.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/mapper/PolicyTemplateObjectMapper.java
@@ -1,6 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2024 T-Systems International GmbH
- * Copyright (c) 2024, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/mapper/PolicyTemplateObjectMapper.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/mapper/PolicyTemplateObjectMapper.java
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.mapper;
+
+import org.eclipse.tractusx.sde.common.entities.PolicyTemplateRequest;
+import org.mapstruct.Mapper;
+
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.SneakyThrows;
+
+@Mapper(componentModel = "spring")
+public abstract class PolicyTemplateObjectMapper {
+
+	ObjectMapper mapper = new ObjectMapper();
+
+	@SneakyThrows
+	public PolicyTemplateRequest strToObject(String metaData) {
+		final DeserializationConfig originalConfig = mapper.getDeserializationConfig();
+		final DeserializationConfig newConfig = originalConfig.with(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+		mapper.setConfig(newConfig);
+		return mapper.readValue(metaData, PolicyTemplateRequest.class);
+	}
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/utils/PolicyOperationUtil.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/utils/PolicyOperationUtil.java
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.common.utils;
+
+import java.util.List;
+
+import org.eclipse.tractusx.sde.common.entities.Policies;
+import org.eclipse.tractusx.sde.common.entities.PolicyModel;
+
+public class PolicyOperationUtil {
+	
+	private PolicyOperationUtil() {}
+
+	private static List<String> getBPNList(List<Policies> policies) {
+		return policies
+				.stream()
+				.filter(e -> e.getTechnicalKey().equals("BusinessPartnerNumber"))
+				.flatMap(e -> e.getValue().stream())
+				.toList();
+	}
+	
+	public static List<String> getAccessBPNList(PolicyModel policy) {
+		return getBPNList(policy.getAccessPolicies());
+	}
+
+	public static List<String> getUsageBPNList(PolicyModel policy) {
+		return getBPNList(policy.getUsagePolicies());
+	}
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsPojo.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsPojo.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsPojo.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsPojo.java
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2023 T-Systems International GmbH
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.validators;
+
+import org.eclipse.tractusx.sde.common.entities.PolicyTemplateRequest;
+import org.eclipse.tractusx.sde.common.entities.SubmodelJsonReq;
+import org.springframework.stereotype.Service;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+@Service
+public class PolicyTemplateValidationAsPojo
+		implements ConstraintValidator<ValidatePolicyTemplate, SubmodelJsonReq> {
+
+	private final ValidationService validationService;
+
+	public PolicyTemplateValidationAsPojo(ValidationService validationService) {
+		this.validationService = validationService;
+	}
+
+	@Override
+	public void initialize(ValidatePolicyTemplate constraintAnnotation) {
+		ConstraintValidator.super.initialize(constraintAnnotation);
+	}
+
+	@Override
+	public boolean isValid(SubmodelJsonReq obj, ConstraintValidatorContext constraintValidatorContext) {
+
+		PolicyTemplateRequest policyTemplateRequest = PolicyTemplateRequest.builder()
+				.type(obj.getType())
+				.policyName(obj.getPolicyName())
+				.accessPolicies(obj.getAccessPolicies())
+				.usagePolicies(obj.getUsagePolicies())
+				.uuid(obj.getUuid())
+				.build();
+
+		return validationService.isPolicyTemplateRequestValid(policyTemplateRequest, constraintValidatorContext);
+	}
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsString.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsString.java
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2023 T-Systems International GmbH
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.validators;
+
+import org.eclipse.tractusx.sde.common.entities.PolicyTemplateRequest;
+import org.eclipse.tractusx.sde.common.mapper.PolicyTemplateObjectMapper;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+@RequiredArgsConstructor
+public class PolicyTemplateValidationAsString implements ConstraintValidator<ValidatePolicyTemplate, String> {
+
+	private final ValidationService validationService;
+
+	private final PolicyTemplateObjectMapper mapper;
+
+	@Override
+	public void initialize(ValidatePolicyTemplate constraintAnnotation) {
+		ConstraintValidator.super.initialize(constraintAnnotation);
+	}
+
+	@SneakyThrows
+	@Override
+	public boolean isValid(String request, ConstraintValidatorContext constraintValidatorContext) {
+		PolicyTemplateRequest policyTemplateRequest = null;
+		try {
+			policyTemplateRequest = mapper.strToObject(request);
+		} catch (Exception e) {
+			constraintValidatorContext
+					.buildConstraintViolationWithTemplate("Unable to accept policy details :" + e.getMessage())
+					.addConstraintViolation().disableDefaultConstraintViolation();
+			return false;
+		}
+		if (policyTemplateRequest == null) {
+			return false;
+		}
+		return validationService.isPolicyTemplateRequestValid(policyTemplateRequest, constraintValidatorContext);
+
+	}
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsString.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsString.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
- * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsString.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/PolicyTemplateValidationAsString.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/SpringValidator.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/SpringValidator.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.validators;
+
+
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@Component
+public class SpringValidator {
+    public <T> T validate(@Valid T t) {
+        return t;
+    }
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/UsagePolicyValidator.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/UsagePolicyValidator.java
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2023 T-Systems International GmbH
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.validators;
+
+import org.eclipse.tractusx.sde.common.entities.PolicyModel;
+import org.springframework.stereotype.Service;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UsagePolicyValidator implements ConstraintValidator<ValidatePolicyTemplate, PolicyModel> {
+
+	private final ValidationService validationService;
+
+	@Override
+	public void initialize(ValidatePolicyTemplate constraintAnnotation) {
+		ConstraintValidator.super.initialize(constraintAnnotation);
+	}
+
+	public boolean isValid(PolicyModel policy, ConstraintValidatorContext constraintValidatorContext) {
+		boolean policyName = validationService.policyName(policy.getPolicyName(), constraintValidatorContext);
+		boolean access = validationService.accessPoliciesValidation(policy.getAccessPolicies(), constraintValidatorContext);
+		boolean usage = validationService.usagePoliciesValidation(policy.getUsagePolicies(), constraintValidatorContext);
+		return policyName && access && usage;
+	}
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/UsagePolicyValidator.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/UsagePolicyValidator.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
- * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/UsagePolicyValidator.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/UsagePolicyValidator.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidatePolicyTemplate.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidatePolicyTemplate.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidatePolicyTemplate.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidatePolicyTemplate.java
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2023 T-Systems International GmbH
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.validators;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = { PolicyTemplateValidationAsPojo.class, PolicyTemplateValidationAsString.class,
+		UsagePolicyValidator.class })
+public @interface ValidatePolicyTemplate {
+
+	String message() default "policy must not be null";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidationService.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidationService.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidationService.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/validators/ValidationService.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023, 2024 T-Systems International GmbH
- * Copyright (c) 2022, 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/controller/PolicyHubController.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/controller/PolicyHubController.java
@@ -1,0 +1,95 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.core.controller;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+import java.util.List;
+
+import org.eclipse.tractusx.sde.policyhub.handler.IPolicyHubProxyService;
+import org.eclipse.tractusx.sde.policyhub.model.request.PolicyContentRequest;
+import org.eclipse.tractusx.sde.policyhub.model.response.PolicyTypeResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/policy-hub")
+public class PolicyHubController {
+	
+	@Autowired
+	private IPolicyHubProxyService policyHubProxyService;
+	
+	
+	@GetMapping(value = "/policy-attributes")
+	@PreAuthorize("hasPermission('','policyhub_view_policy_attributes')")
+	public ResponseEntity<List<String>> policyAttributes() throws Exception {
+		
+		log.info("Request received : /policy-hub/policy-attributes");
+		List<String> policyAttributesResponse = policyHubProxyService.getPolicyAttributes();
+		return ok().body(policyAttributesResponse);
+	}
+	
+	
+	@GetMapping(value = "/policy-types")
+	@PreAuthorize("hasPermission('','policyhub_view_policy_types')")
+	public ResponseEntity<List<PolicyTypeResponse>> policyTypes(@RequestParam(value = "type", required = false) String type,
+			@RequestParam(value = "useCase", required = false) String useCase) throws Exception {
+		
+		log.info("Request received : /policy-hub/policy-types");
+		List<PolicyTypeResponse> policyTypesResponse = policyHubProxyService.getPolicyTypes(type, useCase);
+		return ok().body(policyTypesResponse);
+	}
+	
+	@GetMapping(value = "/policy-content")
+	@PreAuthorize("hasPermission('','policyhub_view_policy_content')")
+	public ResponseEntity<JsonNode> policyContent(@RequestParam(value = "useCase", required = false) String useCase,
+			@RequestParam(value = "type", required = true) String type,
+			@RequestParam(value = "credential", required = true) String credential,
+			@RequestParam(value = "operatorId", required = true) String operatorId,
+			@RequestParam(value = "value", required = false) String value) throws Exception {
+		
+		log.info("Request received : /policy-hub/policy-content");
+		JsonNode policyResponse = policyHubProxyService.getPolicyContent(useCase, type, credential, operatorId, value);
+		return ok().body(policyResponse);
+	}
+	
+	@PostMapping(value = "/policy-content")
+	@PreAuthorize("hasPermission('','policyhub_policy_content')")
+	public ResponseEntity<JsonNode> policyContent(@RequestBody PolicyContentRequest policyContentRequest) throws Exception {
+		
+		log.info("Request received : /policy-hub/policy-content");
+		JsonNode policyResponse = policyHubProxyService.getPolicyContent(policyContentRequest);
+		return ok().body(policyResponse);
+	}
+	
+
+}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

### Added
- Added Policy-hub Proxy controller.
- Added New Policy Entities and pojo classes.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
