### PR TITLE
[Fix|sde-backend] Docker Image changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fix new dDTR support changes.
 - Fixed Vulnerability logback issue of CVE-2023-6481.
+- Docker image updated to fix vulnerability.
 
 ## [2.3.4] - 2023-12-21
 ### Fixed

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -36,7 +36,7 @@ in the GitHub organization https://github.com/eclipse-tractusx:
 
 This project leverages the following third party content.
 
-See DEPENDENCIES file.
+See DEPENDENCIES file (https://github.com/catenax-ng/tx-managed-simple-data-exchanger-backend/blob/main/DEPENDENCIES).
 
 ## Cryptography
 

--- a/README.md
+++ b/README.md
@@ -369,8 +369,7 @@ Eclipse Tractus-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0] https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/blob/main/LICENSE
 
 **Used base image**
-- [eclipse-temurin:17.0.9_9-jdk-jammy](https://github.com/adoptium/containers)
-ners)
+- [eclipse-temurin:17.0.10_7-jdk-focal](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin  
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin  
 - Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 #################################################################################
 # Copyright (c) 2022,2023 T-Systems International GmbH
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2023,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -31,7 +31,7 @@ RUN mvn clean install
 
 # our final base image
 
-FROM eclipse-temurin:17.0.9_9-jdk-jammy
+FROM eclipse-temurin:17.0.10_7-jdk-focal
 
 ARG USERNAME=sdeuser
 ARG USER_UID=1001

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 #################################################################################
-# Copyright (c) 2022,2023 T-Systems International GmbH
-# Copyright (c) 2022,2023,2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 T-Systems International GmbH
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.


### PR DESCRIPTION
## Description
- Docker image changed to fix vulnerability.
- fix for CVE-2023-38545,CVE-2023-4911


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
