### PR TITLE
[feat|sde-backend] : New changes for Cache ddtr bpn discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added New Policy Entities and pojo classes.
 - Draft code of Policies changes.
 - Added new classes for file download history
+- Added new classes for files for cache ddtr and bpndiscovery twin search 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [Unreleased] - 2023-02-13
+## [Unreleased]
 
 ### Added
 
 - Policy-Hub service api integration.
 - Added New Policy Entities and pojo classes.
 - Draft code of Policies changes.
+- Added new classes for file download history
 
 ### Fixed
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,39 +1,39 @@
-maven/mavencentral/ch.qos.logback/logback-classic/1.4.13, EPL-1.0 OR LGPL-2.1-only, approved, #3435
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3435
-maven/mavencentral/ch.qos.logback/logback-classic/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3435
-maven/mavencentral/ch.qos.logback/logback-core/1.4.13, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/ch.qos.logback/logback-core/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3373
-maven/mavencentral/ch.qos.logback/logback-core/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.ethlo.time/itu/1.7.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.0, Apache-2.0, approved, #7947
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.0, MIT AND Apache-2.0, approved, #7932
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.0, Apache-2.0, approved, #7934
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-toml/2.15.0, Apache-2.0, approved, #9160
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.0, Apache-2.0, approved, #8802
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.15.0, Apache-2.0, approved, #8808
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.0, Apache-2.0, approved, #7930
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.15.0, Apache-2.0, approved, #8803
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, MIT AND Apache-2.0, approved, #7932
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-toml/2.15.3, Apache-2.0, approved, #9160
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.3, Apache-2.0, approved, #8802
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.15.3, Apache-2.0, approved, #8808
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.3, Apache-2.0, approved, #7930
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.15.3, Apache-2.0, approved, #8803
 maven/mavencentral/com.fasterxml/classmate/1.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.1.6, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.1.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
 maven/mavencentral/com.google.code.gson/gson/2.10, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.21.1, Apache-2.0, approved, #9834
 maven/mavencentral/com.jayway.jsonpath/json-path/2.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.72, Apache-2.0, approved, CQ22638
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.31, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.sun.istack/istack-commons-runtime/4.1.1, BSD-3-Clause, approved, #2590
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.24.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.opencsv/opencsv/5.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.sun.istack/istack-commons-runtime/4.1.2, BSD-3-Clause, approved, #2590
 maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1, Apache-2.0, approved, CQ21310
 maven/mavencentral/com.zaxxer/HikariCP/5.0.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
 maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
+maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-io/commons-io/2.7, Apache-2.0, approved, clearlydefined
+maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
 maven/mavencentral/io.github.openfeign.form/feign-form-spring/3.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.openfeign.form/feign-form/3.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.openfeign/feign-core/12.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.openfeign/feign-slf4j/12.3, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-commons/1.11.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
-maven/mavencentral/io.micrometer/micrometer-observation/1.11.0, Apache-2.0, approved, #9242
+maven/mavencentral/io.micrometer/micrometer-commons/1.11.6, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
+maven/mavencentral/io.micrometer/micrometer-observation/1.11.6, Apache-2.0, approved, #9242
 maven/mavencentral/io.smallrye/jandex/3.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
@@ -44,31 +44,27 @@ maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved
 maven/mavencentral/jakarta.persistence/jakarta.persistence-api/3.1.0, EPL-2.0 OR BSD-3-Clause AND (EPL-2.0 OR BSD-3-Clause AND BSD-3-Clause), approved, #7696
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
-maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.4, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.4, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.minidev/accessors-smart/2.4.9, Apache-2.0, approved, #7515
-maven/mavencentral/net.minidev/json-smart/2.4.10, Apache-2.0, approved, #3288
+maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.1, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.10, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.10, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.minidev/accessors-smart/2.4.11, Apache-2.0, approved, #7515
+maven/mavencentral/net.minidev/json-smart/2.4.11, Apache-2.0, approved, #3288
 maven/mavencentral/org.antlr/antlr4-runtime/4.10.1, BSD-3-Clause AND LicenseRef-Public-domain AND MIT AND LicenseRef-Unicode-TOU, approved, #7065
+maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-csv/1.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.17.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.17.1, Apache-2.0, approved, #2163
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.16, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.8, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.8, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.8, Apache-2.0, approved, #7920
-maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/10.1.8, Apache-2.0, approved, #8196
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.16, Apache-2.0, approved, #6997
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.16, Apache-2.0, approved, #7920
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.aspectj/aspectjweaver/1.9.19, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
+maven/mavencentral/org.aspectj/aspectjweaver/1.9.20.1, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
-maven/mavencentral/org.bouncycastle/bcpkix-jdk15on/1.69, MIT, approved, clearlydefined
-maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.69, MIT, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
-maven/mavencentral/org.bouncycastle/bcutil-jdk15on/1.69, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.33.0, MIT, approved, clearlydefined
-maven/mavencentral/org.eclipse.angus/angus-activation/2.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
+maven/mavencentral/org.eclipse.angus/angus-activation/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.persistence/eclipselink/3.0.3, EPL-2.0 OR BSD-3-Clause, approved, ee4j.eclipselink
 maven/mavencentral/org.eclipse.tractusx/assembly-part-relationship/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx/batch/0.0.1, Apache-2.0, approved, automotive.tractusx
@@ -85,14 +81,14 @@ maven/mavencentral/org.eclipse.tractusx/serial-part-typization/0.0.1, Apache-2.0
 maven/mavencentral/org.eclipse.tractusx/single-level-bom-as-planned/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx/single-level-usage-as-built/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/9.16.3, Apache-2.0, approved, #7935
-maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.2, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.2, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/org.glassfish.jaxb/txw2/4.0.2, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/txw2/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hibernate.common/hibernate-commons-annotations/6.0.6.Final, LGPL-2.1-only, approved, #6962
-maven/mavencentral/org.hibernate.orm/hibernate-core/6.2.2.Final, LGPL-2.1-only AND Apache-2.0 AND MIT AND CC-PDDC AND (EPL-2.0 OR BSD-3-Clause), approved, #9121
-maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.0.Final, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.jboss.logging/jboss-logging/3.5.0.Final, Apache-2.0, approved, #9471
+maven/mavencentral/org.hibernate.orm/hibernate-core/6.2.13.Final, LGPL-2.1-only AND Apache-2.0 AND MIT AND CC-PDDC AND (EPL-2.0 OR BSD-3-Clause), approved, #9121
+maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.jboss.logging/jboss-logging/3.5.3.Final, Apache-2.0, approved, #9471
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.3, EPL-2.0, approved, #3125
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approved, #3134
@@ -106,64 +102,60 @@ maven/mavencentral/org.objenesis/objenesis/3.2, Apache-2.0, approved, clearlydef
 maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.postgresql/postgresql/42.6.0, BSD-2-Clause AND Apache-2.0, approved, #9159
-maven/mavencentral/org.projectlombok/lombok/1.18.26, MIT AND LicenseRef-Public-Domain, approved, CQ23907
+maven/mavencentral/org.projectlombok/lombok/1.18.30, MIT AND LicenseRef-Public-Domain, approved, CQ23907
 maven/mavencentral/org.skyscreamer/jsonassert/1.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.7, MIT, approved, #7698
-maven/mavencentral/org.slf4j/slf4j-api/2.0.7, MIT, approved, #5915
+maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.9, MIT, approved, #7698
+maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.2, Apache-2.0, approved, #5920
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.2, Apache-2.0, approved, #5950
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.2, Apache-2.0, approved, #5923
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.0, Apache-2.0, approved, #9341
-maven/mavencentral/org.springframework.boot/spring-boot-devtools/3.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.0, Apache-2.0, approved, #9338
-maven/mavencentral/org.springframework.boot/spring-boot-starter-cache/3.1.0, Apache-2.0, approved, #9653
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.1.0, Apache-2.0, approved, #9733
-maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.1.0, Apache-2.0, approved, #9737
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.0, Apache-2.0, approved, #9336
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.0, Apache-2.0, approved, #9343
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.1.0, Apache-2.0, approved, #8804
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.1.0, Apache-2.0, approved, #9337
-maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.1.0, Apache-2.0, approved, #9353
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.0, Apache-2.0, approved, #9351
-maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.1.0, Apache-2.0, approved, #9335
-maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.1.0, Apache-2.0, approved, #9347
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.0, Apache-2.0, approved, #9349
-maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.1.0, Apache-2.0, approved, #9339
-maven/mavencentral/org.springframework.boot/spring-boot-test/3.1.0, Apache-2.0, approved, #9346
-maven/mavencentral/org.springframework.boot/spring-boot/3.1.0, Apache-2.0, approved, #9352
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.6, Apache-2.0, approved, #9341
+maven/mavencentral/org.springframework.boot/spring-boot-devtools/3.1.6, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.6, Apache-2.0, approved, #9338
+maven/mavencentral/org.springframework.boot/spring-boot-starter-cache/3.1.6, Apache-2.0, approved, #9653
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.1.6, Apache-2.0, approved, #9733
+maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.1.6, Apache-2.0, approved, #9737
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.6, Apache-2.0, approved, #9336
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.6, Apache-2.0, approved, #9343
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.1.6, Apache-2.0, approved, #8804
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.1.6, Apache-2.0, approved, #9337
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.1.6, Apache-2.0, approved, #9353
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.6, Apache-2.0, approved, #9351
+maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.1.6, Apache-2.0, approved, #9335
+maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.1.6, Apache-2.0, approved, #9347
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.6, Apache-2.0, approved, #9349
+maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.1.6, Apache-2.0, approved, #9339
+maven/mavencentral/org.springframework.boot/spring-boot-test/3.1.6, Apache-2.0, approved, #9346
+maven/mavencentral/org.springframework.boot/spring-boot/3.1.6, Apache-2.0, approved, #9352
 maven/mavencentral/org.springframework.cloud/spring-cloud-commons/4.0.3, Apache-2.0, approved, #7292
 maven/mavencentral/org.springframework.cloud/spring-cloud-context/4.0.3, Apache-2.0, approved, #7306
 maven/mavencentral/org.springframework.cloud/spring-cloud-openfeign-core/4.0.3, Apache-2.0, approved, #7305
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter-openfeign/4.0.3, Apache-2.0, approved, #7302
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter/4.0.3, Apache-2.0, approved, #7299
-maven/mavencentral/org.springframework.data/spring-data-commons/3.1.0, Apache-2.0, approved, #8805
-maven/mavencentral/org.springframework.data/spring-data-jpa/3.1.0, Apache-2.0, approved, #9120
-maven/mavencentral/org.springframework.security/spring-security-config/6.1.0, Apache-2.0, approved, #9736
+maven/mavencentral/org.springframework.data/spring-data-commons/3.1.6, Apache-2.0, approved, #8805
+maven/mavencentral/org.springframework.data/spring-data-jpa/3.1.6, Apache-2.0, approved, #9120
 maven/mavencentral/org.springframework.security/spring-security-config/6.1.2, Apache-2.0, approved, #9736
-maven/mavencentral/org.springframework.security/spring-security-core/6.1.0, Apache-2.0, approved, #9801
 maven/mavencentral/org.springframework.security/spring-security-core/6.1.2, Apache-2.0, approved, #9801
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.0, Apache-2.0 AND ISC, approved, #9735
-maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.0, Apache-2.0, approved, #9741
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.0, Apache-2.0, approved, #9345
-maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.1.0, Apache-2.0, approved, #8798
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.5, Apache-2.0 AND ISC, approved, #9735
+maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.5, Apache-2.0, approved, #9741
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.5, Apache-2.0, approved, #9345
+maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.1.5, Apache-2.0, approved, #8798
 maven/mavencentral/org.springframework.security/spring-security-rsa/1.0.11.RELEASE, Apache-2.0, approved, CQ20647
-maven/mavencentral/org.springframework.security/spring-security-web/6.1.0, Apache-2.0, approved, #9800
-maven/mavencentral/org.springframework/spring-aop/6.0.9, Apache-2.0, approved, #5940
-maven/mavencentral/org.springframework/spring-aspects/6.0.9, Apache-2.0, approved, #5930
-maven/mavencentral/org.springframework/spring-beans/6.0.9, Apache-2.0, approved, #5937
-maven/mavencentral/org.springframework/spring-context-support/6.0.9, Apache-2.0, approved, #6960
-maven/mavencentral/org.springframework/spring-context/6.0.9, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.9, Apache-2.0 AND BSD-3-Clause, approved, #5948
-maven/mavencentral/org.springframework/spring-expression/6.0.9, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-jcl/6.0.9, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-jdbc/6.0.9, Apache-2.0, approved, #5924
-maven/mavencentral/org.springframework/spring-orm/6.0.9, Apache-2.0, approved, #5925
-maven/mavencentral/org.springframework/spring-test/6.0.9, Apache-2.0, approved, #7003
-maven/mavencentral/org.springframework/spring-tx/6.0.9, Apache-2.0, approved, #5926
+maven/mavencentral/org.springframework.security/spring-security-web/6.1.5, Apache-2.0, approved, #9800
+maven/mavencentral/org.springframework/spring-aop/6.0.14, Apache-2.0, approved, #5940
+maven/mavencentral/org.springframework/spring-aspects/6.0.14, Apache-2.0, approved, #5930
+maven/mavencentral/org.springframework/spring-beans/6.0.14, Apache-2.0, approved, #5937
+maven/mavencentral/org.springframework/spring-context-support/6.0.14, Apache-2.0, approved, #6960
+maven/mavencentral/org.springframework/spring-context/6.0.14, Apache-2.0, approved, #5936
+maven/mavencentral/org.springframework/spring-core/6.0.14, Apache-2.0 AND BSD-3-Clause, approved, #5948
+maven/mavencentral/org.springframework/spring-expression/6.0.14, Apache-2.0, approved, #3284
+maven/mavencentral/org.springframework/spring-jcl/6.0.14, Apache-2.0, approved, #3283
+maven/mavencentral/org.springframework/spring-jdbc/6.0.14, Apache-2.0, approved, #5924
+maven/mavencentral/org.springframework/spring-orm/6.0.14, Apache-2.0, approved, #5925
+maven/mavencentral/org.springframework/spring-test/6.0.14, Apache-2.0, approved, #7003
+maven/mavencentral/org.springframework/spring-tx/6.0.14, Apache-2.0, approved, #5926
 maven/mavencentral/org.springframework/spring-web/6.0.14, Apache-2.0, approved, #5942
-maven/mavencentral/org.springframework/spring-web/6.0.9, Apache-2.0, approved, #5942
 maven/mavencentral/org.springframework/spring-webmvc/6.0.14, Apache-2.0, approved, #5944
-maven/mavencentral/org.springframework/spring-webmvc/6.0.9, Apache-2.0, approved, #5944
 maven/mavencentral/org.webjars/swagger-ui/4.15.5, Apache-2.0 AND MIT, approved, #5921
 maven/mavencentral/org.webjars/webjars-locator-core/0.52, MIT, approved, clearlydefined
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/model/Acknowledgement.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/model/Acknowledgement.java
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Acknowledgement {
+
+	private String id;
+
+}

--- a/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/model/PagingResponse.java
+++ b/modules/sde-common/src/main/java/org/eclipse/tractusx/sde/common/model/PagingResponse.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.common.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PagingResponse {
+
+	private int page;
+	private int pageSize;
+	private long totalItems;
+	private Object items;
+}

--- a/modules/sde-core/pom.xml
+++ b/modules/sde-core/pom.xml
@@ -2,8 +2,8 @@
 <!-- 
 /******************************************************************************** 
 * Copyright (c) 2022 BMW GmbH 
-* Copyright (c) 2022,2023 T-Systems International GmbH 
-* Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation 
+* Copyright (c) 2022, 2024 T-Systems International GmbH 
+* Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation 
 * 
 * See the NOTICE file(s) distributed with this work for additional 
 * information regarding copyright ownership. 
@@ -183,6 +183,13 @@
 			<artifactId>pcf</artifactId>
 			<version>0.0.1</version>
 		</dependency>
+		
+		<dependency>
+		    <groupId>com.opencsv</groupId>
+		    <artifactId>opencsv</artifactId>
+		    <version>5.8</version>
+		</dependency>
+		
 	</dependencies>
 
 	<build>

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/entity/ConsumerDownloadHistoryEntity.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/entity/ConsumerDownloadHistoryEntity.java
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.core.processreport.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Table(name = "consumer_download_history")
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Cacheable(value = false)
+public class ConsumerDownloadHistoryEntity {
+	@Id
+	@Column(name = "process_id")
+	private String processId;
+	@Column(name = "provider_url")
+	private String providerUrl;
+	@Column(name = "connector_id")
+	private String connectorId;
+	@Column(name = "number_of_items")
+	private Integer numberOfItems;
+	@Column(name = "download_failed")
+	private Integer downloadFailed;
+	@Column(name = "download_successed")
+	private Integer downloadSuccessed;
+	@Column(name = "status")
+	private String status;
+	@Column(name = "start_date")
+	private LocalDateTime startDate;
+	@Column(name = "end_date")
+	private LocalDateTime endDate;
+	
+	@Lob
+	@Column(name = "offers")
+	private String offers;
+	@Lob
+	private String policies;
+	private String referenceProcessId;
+
+}

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/mapper/ConsumerDownloadHistoryMapper.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/mapper/ConsumerDownloadHistoryMapper.java
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.core.processreport.mapper;
+
+import java.util.List;
+
+import org.eclipse.tractusx.sde.common.entities.PolicyModel;
+import org.eclipse.tractusx.sde.core.processreport.entity.ConsumerDownloadHistoryEntity;
+import org.eclipse.tractusx.sde.core.processreport.model.ConsumerDownloadHistory;
+import org.eclipse.tractusx.sde.edc.model.contractnegotiation.Offer;
+import org.mapstruct.Mapper;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.SneakyThrows;
+
+@Mapper(componentModel = "spring")
+public interface ConsumerDownloadHistoryMapper {
+
+	ObjectMapper mapper = new ObjectMapper();
+
+	ConsumerDownloadHistory mapFrom(ConsumerDownloadHistoryEntity entity);
+
+	@SneakyThrows
+	default ConsumerDownloadHistory mapFromCustom(ConsumerDownloadHistoryEntity entity) {
+		ConsumerDownloadHistory mapFrom = mapFrom(entity);
+		
+		if (entity.getOffers() != null)
+			mapFrom.setOffers(mapper.readValue(entity.getOffers(), new TypeReference<List<Offer>>() {
+			}));
+		if (entity.getPolicies() != null)
+			mapFrom.setPolicies(mapper.readValue(entity.getPolicies(), new TypeReference<List<PolicyModel>>() {
+			}));
+			
+		return mapFrom;
+	}
+}

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/model/ConsumerDownloadHistory.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/model/ConsumerDownloadHistory.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.core.processreport.model;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConsumerDownloadHistory {
+	
+
+	private String processId;
+	private String providerUrl;
+	private String connectorId;
+	private Integer numberOfItems;
+	private Integer downloadFailed;
+	private Integer downloadSuccessed;
+	private String status;
+	private LocalDateTime startDate;
+	private LocalDateTime endDate;
+	private Object offers;
+	private Object policies;
+    private String referenceProcessId;
+
+}

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/repository/ConsumerDownloadHistoryRepository.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/processreport/repository/ConsumerDownloadHistoryRepository.java
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.core.processreport.repository;
+
+
+import org.eclipse.tractusx.sde.core.processreport.entity.ConsumerDownloadHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConsumerDownloadHistoryRepository extends JpaRepository<ConsumerDownloadHistoryEntity, String> {
+
+	ConsumerDownloadHistoryEntity findByProcessId(String id);
+
+}

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/properties/SdeCommonProperties.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/properties/SdeCommonProperties.java
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.core.properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@Getter
+public class SdeCommonProperties {
+	
+	//DigitalTwin properties
+	@Value("${digital-twins.hostname:default}")
+	private  String digitalTwinRegistry;
+			
+	@Value("${digital-twins.managed.thirdparty:false}")
+	private boolean dDTRManagedThirdparty;
+	
+	@Value("${digital-twins.registry.uri:/api/v3.0}")
+	private  String digitalTwinRegistryURI;
+	
+	@Value("${digital-twins.authentication.url:default}")
+	private String digitalTwinTokenUrl;
+	
+	@Value("${digital-twins.authentication.clientId:default}")
+	private String digitalTwinClientId;
+	
+	@Value("${digital-twins.authentication.clientSecret:default}")
+	private String digitalTwinClientSecret;
+	
+	@Value("${digital-twins.authentication.scope:}")
+	private String digitalTwinAuthenticationScope;
+	
+	//manufacturer Id properties
+	@Value(value = "${manufacturerId}")
+	private String manufacturerId;
+
+}

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/utils/ValueReplacerUtility.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/core/utils/ValueReplacerUtility.java
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.core.utils;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.apache.commons.text.StringSubstitutor;
+import org.eclipse.tractusx.sde.common.exception.ServiceException;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+
+import lombok.SneakyThrows;
+
+@Component
+public class ValueReplacerUtility {
+
+	@SneakyThrows
+	public String getRequestFile(String schemaFile) {
+		JsonParser createParser = null;
+		String schema = null;
+		try {
+			MappingJsonFactory jf = new MappingJsonFactory();
+			InputStream jsonFile = this.getClass().getResourceAsStream(schemaFile);
+
+			if (jsonFile == null) {
+				// this is how we load file within editor (eg eclipse)
+				jsonFile = this.getClass().getClassLoader().getResourceAsStream(schemaFile);
+			}
+			createParser = jf.createParser(jsonFile);
+			schema = createParser.readValueAsTree().toString();
+			if (schema == null) {
+				throw new ServiceException("The schema file is null " + schemaFile);
+			}
+
+			return schema;
+		} finally {
+			if (createParser != null)
+				createParser.close();
+		}
+	}
+
+	@SneakyThrows
+	public String valueReplacer(String requestTemplate, Map<String, String> inputData) {
+		StringSubstitutor stringSubstitutor1 = new StringSubstitutor(inputData);
+		return stringSubstitutor1.replace(requestTemplate);
+	}
+	
+	@SneakyThrows
+	public String valueReplacerUsingFileTemplate(String requestTemplatePath, Map<String, String> inputData) {
+		StringSubstitutor stringSubstitutor1 = new StringSubstitutor(inputData);
+		return stringSubstitutor1.replace(getRequestFile(requestTemplatePath));
+	}
+
+}

--- a/modules/sde-core/src/main/resources/edc_request_template
/edc_asset_lookup.json
+++ b/modules/sde-core/src/main/resources/edc_request_template
/edc_asset_lookup.json
@@ -1,0 +1,22 @@
+{
+	"@context": {
+		"edc": "https://w3id.org/edc/v0.0.1/ns/"
+	},
+	"@type": "QuerySpec",
+	"offset": 0,
+	"limit": 10,
+	"sortOrder": "DESC",
+	"sortField": "id",
+	"filterExpression": [
+		{
+			"edc:operandLeft": "https://w3id.org/edc/v0.0.1/ns/type",
+			"edc:operator": "=",
+			"edc:operandRight": "data.core.digitalTwinRegistry"
+		},
+		{
+			"edc:operandLeft": "https://w3id.org/edc/v0.0.1/ns/registry",
+			"edc:operator": "=",
+			"edc:operandRight": "${digitalTwinRegistry}"
+		}
+	]
+}

--- a/modules/sde-core/src/main/resources/edc_request_template
/edc_asset_lookup_for_exchange.json
+++ b/modules/sde-core/src/main/resources/edc_request_template
/edc_asset_lookup_for_exchange.json
@@ -1,0 +1,9 @@
+{
+	"filterExpression": [
+		{
+			"operandLeft": "https://w3id.org/edc/v0.0.1/ns/type",
+			"operator": "=",
+			"operandRight": "data.core.digitalTwinRegistry"
+		}
+	]
+}

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/api/ContractApi.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/api/ContractApi.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -37,6 +37,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 @FeignClient(name = "ContractApi", url = "placeholder")
 public interface ContractApi {
 
@@ -66,5 +68,18 @@ public interface ContractApi {
 	ResponseEntity<Object> cancelContract(URI url,
 			@PathVariable("contractnegotiationsId") String contractnegotiationsId,
 			@RequestHeader Map<String, String> requestHeader);
+
+	@PostMapping(path = "/contractagreements/request", consumes = MediaType.APPLICATION_JSON_VALUE)
+	List<JsonNode> getAllContractAgreements(URI url, @RequestHeader Map<String, String> requestHeader,
+			@RequestBody JsonNode rquestBody);
+	
+	@GetMapping(path = "/contractagreements/{contractAgreement}/negotiation")
+	ContractNegotiationDto getContractAgreementsNegotiation(URI url, @PathVariable("contractAgreement") String contractAgreement,
+			@RequestHeader Map<String, String> requestHeader);
+
+	
+	@PostMapping(path = "/transferprocesses/request", consumes = MediaType.APPLICATION_JSON_VALUE)
+	List<JsonNode> getAllTransfer(URI uri, @RequestHeader Map<String, String> providerAuthHeader,
+			@RequestBody JsonNode body);
 
 }

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/facilitator/ContractNegotiateManagementHelper.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/facilitator/ContractNegotiateManagementHelper.java
@@ -44,6 +44,7 @@ import org.eclipse.tractusx.sde.edc.util.UtilityFunctions;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -56,12 +57,18 @@ public class ContractNegotiateManagementHelper extends AbstractEDCStepsHelper {
 	private final ContractApi contractApi;
 	private final ContractMapper contractMapper;
 
+	ObjectMapper mapper = new ObjectMapper();
+
 	@SneakyThrows
 	public String negotiateContract(String providerUrl, String providerId, String offerId, String assetId,
 			ActionRequest action, Map<String, String> extensibleProperty) {
 
-		ContractNegotiations contractNegotiations = contractMapper
-				.prepareContractNegotiations(providerUrl + protocolPath, offerId, assetId, providerId, action);
+		var recipientURL = UtilityFunctions.removeLastSlashOfUrl(providerUrl);
+		if (!recipientURL.endsWith(protocolPath))
+			recipientURL = recipientURL + protocolPath;
+
+		ContractNegotiations contractNegotiations = contractMapper.prepareContractNegotiations(recipientURL, offerId,
+				assetId, providerId, action);
 
 		AcknowledgementId acknowledgementId = contractApi.contractnegotiations(new URI(consumerHost),
 				contractNegotiations, getAuthHeader());
@@ -85,6 +92,68 @@ public class ContractNegotiateManagementHelper extends AbstractEDCStepsHelper {
 
 	}
 
+	@SneakyThrows
+	public List<JsonNode> getAllContractAgreements(String assetId, String type, Integer offset, Integer limit) {
+
+		Map<String, String> inputMap = new HashMap<>();
+		inputMap.put("operandLeft", "assetId");
+		inputMap.put("operandRight", assetId);
+		inputMap.put("offset", offset + "");
+		inputMap.put("limit", limit + "");
+
+		JsonNode body = getQurySpec(inputMap);
+
+		if (UtilityFunctions.checkTypeOfConnector(type)) {
+			return contractApi.getAllContractAgreements(new URI(providerHost), getProviderAuthHeader(), body);
+		} else
+			return contractApi.getAllContractAgreements(new URI(consumerHost), getAuthHeader(), body);
+	}
+
+	@SneakyThrows
+	public ContractNegotiationDto checkContractAgreementNegotiationStatus(String contractAgreement) {
+		return contractApi.getContractAgreementsNegotiation(new URI(consumerHost), contractAgreement, getAuthHeader());
+	}
+
+	@SneakyThrows
+	public List<JsonNode> getAllTransfer(String assetId, String type, Integer offset, Integer limit) {
+		Map<String, String> inputMap = new HashMap<>();
+		inputMap.put("operandLeft", "dataRequest.assetId");
+		inputMap.put("operandRight", assetId);
+		inputMap.put("offset", offset + "");
+		inputMap.put("limit", limit + "");
+
+		JsonNode body = getQurySpec(inputMap);
+
+		if (UtilityFunctions.checkTypeOfConnector(type)) {
+			return contractApi.getAllTransfer(new URI(providerHost), getProviderAuthHeader(), body);
+		} else
+			return contractApi.getAllTransfer(new URI(consumerHost), getAuthHeader(), body);
+	}
+
+	@SneakyThrows
+	private JsonNode getQurySpec(Map<String, String> inputMap) {
+
+		String querySpec = """
+						{
+						    "@context": {
+						        "edc": "https://w3id.org/edc/v0.0.1/ns/"
+						    },
+						    "@type": "QuerySpec",
+						    "offset": ${offset},
+						    "limit": ${limit},
+						    "sortOrder": "DESC",
+						    "filterExpression": [
+						        {
+						            "operandLeft": "${operandLeft}",
+						            "operator": "=",
+						            "operandRight": "${operandRight}"
+						        }
+						    ]
+						}
+				""";
+		return mapper.readTree(UtilityFunctions.valueReplacer(querySpec, inputMap));
+	}
+
 	@SuppressWarnings("unchecked")
 	@SneakyThrows
 	public ContractAgreementResponse getAgreementBasedOnNegotiationId(String type, String negotiationId) {
@@ -102,19 +171,17 @@ public class ContractNegotiateManagementHelper extends AbstractEDCStepsHelper {
 		if (agreement != null) {
 			List<Policies> policies = new ArrayList<>();
 			Object permissionObj = agreement.getPolicy().getPermissions();
-			
+
 			if (permissionObj instanceof ArrayList) {
 				for (Object obj : (ArrayList<Object>) permissionObj)
 					formatPermissionConstraint(objeMapper, policies, obj);
 			} else if (permissionObj != null) {
 				formatPermissionConstraint(objeMapper, policies, permissionObj);
 			}
-			
+
 			if (policies.isEmpty())
 			
-				UtilityFunctions.getUsagePolicies(policies, List.of());
-			
-			
+			UtilityFunctions.getUsagePolicies(policies, List.of());
 			ContractAgreementInfo agreementInfo = ContractAgreementInfo.builder()
 					.contractEndDate(agreement.getContractEndDate())
 					.contractSigningDate(agreement.getContractSigningDate())
@@ -130,8 +197,7 @@ public class ContractNegotiateManagementHelper extends AbstractEDCStepsHelper {
 		return agreementResponse;
 	}
 
-	private void formatPermissionConstraint(ObjectMapper objeMapper, List<Policies> policies,
-			Object permissionObj) {
+	private void formatPermissionConstraint(ObjectMapper objeMapper, List<Policies> policies, Object permissionObj) {
 		ObjectMapper objMapper = new ObjectMapper();
 		PermissionRequest permissionRequest = objMapper.convertValue(permissionObj, PermissionRequest.class);
 
@@ -151,8 +217,8 @@ public class ContractNegotiateManagementHelper extends AbstractEDCStepsHelper {
 					new TypeReference<List<ConstraintRequest>>() {
 					});
 			UtilityFunctions.getUsagePolicies(policies, convertValue);
-		} else if (object !=null ){
-			
+		} else if (object != null) {
+
 			ConstraintRequest convertValue = objeMapper.convertValue(object, ConstraintRequest.class);
 			UtilityFunctions.getUsagePolicies(policies, List.of(convertValue));
 		}
@@ -162,30 +228,32 @@ public class ContractNegotiateManagementHelper extends AbstractEDCStepsHelper {
 		List<ContractAgreementResponse> contractAgreementResponses = new ArrayList<>();
 		List<ContractNegotiationDto> contractNegotiationDtoList = getAllContractNegotiations(type, limit, offset);
 
-		contractNegotiationDtoList.stream().filter(contract-> type.equalsIgnoreCase(contract.getType().name())).forEach(contract -> {
-			if (StringUtils.isNotBlank(contract.getContractAgreementId())
-					&& (contract.getState().equals(NegotiationState.FINALIZED.name())
-					|| (NegotiationState.DECLINED.name().equalsIgnoreCase(contract.getErrorDetail())
-							&& contract.getState().equals(NegotiationState.TERMINATED.name())))) {
-				String negotiationId = contract.getId();
-				ContractAgreementResponse agreementResponse = getAgreementBasedOnNegotiationId(type, negotiationId);
-				agreementResponse.setCounterPartyAddress(contract.getCounterPartyAddress());
-				agreementResponse.setDateCreated(contract.getCreatedAt());
-				agreementResponse.setDateUpdated(contract.getUpdatedAt());
-				agreementResponse.setType(contract.getType());
-				agreementResponse.setState(contract.getState());
-				agreementResponse.setErrorDetail(contract.getErrorDetail());
-				contractAgreementResponses.add(agreementResponse);
-			} else {
-				ContractAgreementResponse agreementResponse = ContractAgreementResponse.builder()
-						.contractAgreementId(StringUtils.EMPTY).organizationName(StringUtils.EMPTY)
-						.title(StringUtils.EMPTY).negotiationId(contract.getId()).state(contract.getState())
-						.contractAgreementInfo(null).counterPartyAddress(contract.getCounterPartyAddress())
-						.type(contract.getType()).dateCreated(contract.getCreatedAt())
-						.dateUpdated(contract.getUpdatedAt()).errorDetail(contract.getErrorDetail()).build();
-				contractAgreementResponses.add(agreementResponse);
-			}
-		});
+		contractNegotiationDtoList.stream().filter(contract -> type.equalsIgnoreCase(contract.getType().name()))
+				.forEach(contract -> {
+					if (StringUtils.isNotBlank(contract.getContractAgreementId())
+							&& (contract.getState().equals(NegotiationState.FINALIZED.name())
+									|| (NegotiationState.DECLINED.name().equalsIgnoreCase(contract.getErrorDetail())
+											&& contract.getState().equals(NegotiationState.TERMINATED.name())))) {
+						String negotiationId = contract.getId();
+						ContractAgreementResponse agreementResponse = getAgreementBasedOnNegotiationId(type,
+								negotiationId);
+						agreementResponse.setCounterPartyAddress(contract.getCounterPartyAddress());
+						agreementResponse.setDateCreated(contract.getCreatedAt());
+						agreementResponse.setDateUpdated(contract.getUpdatedAt());
+						agreementResponse.setType(contract.getType());
+						agreementResponse.setState(contract.getState());
+						agreementResponse.setErrorDetail(contract.getErrorDetail());
+						contractAgreementResponses.add(agreementResponse);
+					} else {
+						ContractAgreementResponse agreementResponse = ContractAgreementResponse.builder()
+								.contractAgreementId(StringUtils.EMPTY).organizationName(StringUtils.EMPTY)
+								.title(StringUtils.EMPTY).negotiationId(contract.getId()).state(contract.getState())
+								.contractAgreementInfo(null).counterPartyAddress(contract.getCounterPartyAddress())
+								.type(contract.getType()).dateCreated(contract.getCreatedAt())
+								.dateUpdated(contract.getUpdatedAt()).errorDetail(contract.getErrorDetail()).build();
+						contractAgreementResponses.add(agreementResponse);
+					}
+				});
 
 		Map<String, Object> res = new HashMap<>();
 		if (UtilityFunctions.checkTypeOfConnector(type))

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/facilitator/EDRRequestHelper.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/facilitator/EDRRequestHelper.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 T-Systems International GmbH
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 T-Systems International GmbH
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -36,9 +36,11 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EDRRequestHelper extends AbstractEDCStepsHelper {
 
 	private final EDRApiProxy edrApiProxy;
@@ -49,10 +51,12 @@ public class EDRRequestHelper extends AbstractEDCStepsHelper {
 			ActionRequest action, Map<String, String> extensibleProperty) {
 
 		ContractNegotiations contractNegotiations = contractMapper
-				.prepareContractNegotiations(providerUrl + protocolPath, offerId, assetId, providerId, action);
-
-		AcknowledgementId acknowledgementId = edrApiProxy.edrCacheCreate(new URI(consumerHostWithDataPath), contractNegotiations,
-				getAuthHeader());
+				.prepareContractNegotiations(providerUrl, offerId, assetId, providerId, action);
+		
+		log.info(contractNegotiations.toJsonString());
+		
+		AcknowledgementId acknowledgementId = edrApiProxy.edrCacheCreate(new URI(consumerHostWithDataPath),
+				contractNegotiations, getAuthHeader());
 		return acknowledgementId.getId();
 	}
 
@@ -63,14 +67,16 @@ public class EDRRequestHelper extends AbstractEDCStepsHelper {
 
 	@SneakyThrows
 	public EDRCachedByIdResponse getEDRCachedByTransferProcessId(String transferProcessId) {
-		return edrApiProxy.getEDRCachedByTransferProcessId(new URI(consumerHostWithDataPath), transferProcessId, getAuthHeader());
+		return edrApiProxy.getEDRCachedByTransferProcessId(new URI(consumerHostWithDataPath), transferProcessId,
+				getAuthHeader());
 	}
 
 	@SneakyThrows
-	public Object getDataFromProvider(EDRCachedByIdResponse authorizationToken) {
+	public Object getDataFromProvider(EDRCachedByIdResponse authorizationToken, String endpoint) {
 		Map<String, String> authHeader = new HashMap<>();
 		authHeader.put(authorizationToken.getAuthKey(), authorizationToken.getAuthCode());
-		return edrApiProxy.getActualDataFromProviderDataPlane(new URI(authorizationToken.getEndpoint()), authHeader);
+		return edrApiProxy.getActualDataFromProviderDataPlane(new URI(endpoint),
+				authHeader);
 	}
 
 }

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/model/contractnegotiation/ContractNegotiations.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/model/contractnegotiation/ContractNegotiations.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,12 +25,14 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 
 @Data
 @NoArgsConstructor
@@ -57,4 +59,10 @@ public class ContractNegotiations {
 	private String providerId;
 
 	private Offer offer;
+	
+	@SneakyThrows
+	public String toJsonString() {
+		final ObjectMapper mapper = new ObjectMapper();
+		return mapper.writeValueAsString(this);
+	}
 }

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/model/contractnegotiation/Offer.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/model/contractnegotiation/Offer.java
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,11 +25,13 @@ import org.eclipse.tractusx.sde.edc.entities.request.policies.PolicyRequest;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 
 @Data
 @NoArgsConstructor
@@ -44,4 +46,10 @@ public class Offer {
     private String assetId;
 
     private PolicyRequest policy;
+    
+    @SneakyThrows
+	public String toJsonString() {
+		final ObjectMapper mapper = new ObjectMapper();
+		return mapper.writeValueAsString(this);
+	}
 }

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/services/CatalogResponseBuilder.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/services/CatalogResponseBuilder.java
@@ -1,0 +1,152 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.edc.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.tractusx.sde.common.entities.Policies;
+import org.eclipse.tractusx.sde.common.entities.PolicyModel;
+import org.eclipse.tractusx.sde.edc.api.ContractOfferCatalogApi;
+import org.eclipse.tractusx.sde.edc.constants.EDCAssetConstant;
+import org.eclipse.tractusx.sde.edc.facilitator.AbstractEDCStepsHelper;
+import org.eclipse.tractusx.sde.edc.model.contractoffers.ContractOfferRequestFactory;
+import org.eclipse.tractusx.sde.edc.model.response.QueryDataOfferModel;
+import org.eclipse.tractusx.sde.edc.util.UtilityFunctions;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CatalogResponseBuilder extends AbstractEDCStepsHelper {
+
+	private final ContractOfferCatalogApi contractOfferCatalogApiProxy;
+	private final ContractOfferRequestFactory contractOfferRequestFactory;
+
+	public List<QueryDataOfferModel> queryOnDataOffers(String providerUrl, Integer offset, Integer limit,
+			String filterExpression) {
+
+		providerUrl = UtilityFunctions.removeLastSlashOfUrl(providerUrl);
+
+		if (!providerUrl.endsWith(protocolPath))
+			providerUrl = providerUrl + protocolPath;
+
+		String sproviderUrl = providerUrl;
+
+		List<QueryDataOfferModel> queryOfferResponse = new ArrayList<>();
+
+		JsonNode contractOfferCatalog = contractOfferCatalogApiProxy.getContractOffersCatalog(
+				contractOfferRequestFactory.getContractOfferRequest(sproviderUrl, limit, offset, filterExpression));
+
+		JsonNode jOffer = contractOfferCatalog.get("dcat:dataset");
+		if (jOffer.isArray()) {
+
+			jOffer.forEach(
+					offer -> queryOfferResponse.add(buildContractOffer(sproviderUrl, contractOfferCatalog, offer)));
+
+		} else {
+			queryOfferResponse.add(buildContractOffer(sproviderUrl, contractOfferCatalog, jOffer));
+		}
+
+		return queryOfferResponse;
+	}
+
+	public QueryDataOfferModel buildContractOffer(String sproviderUrl, JsonNode contractOfferCatalog, JsonNode offer) {
+
+		JsonNode policy = offer.get("odrl:hasPolicy");
+
+		String edcstr = "edc:";
+
+		QueryDataOfferModel build = QueryDataOfferModel.builder()
+				.assetId(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_ID))
+				.connectorOfferUrl(sproviderUrl).offerId(getFieldFromJsonNode(policy, "@id"))
+				.title(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_NAME))
+				.type(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_TYPE))
+				.description(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_DESCRIPTION))
+				.created(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_CREATED))
+				.modified(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_MODIFIED))
+				.publisher(getFieldFromJsonNode(contractOfferCatalog, edcstr + "participantId"))
+				.version(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_VERSION))
+				.fileName(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_FILENAME))
+				.fileContentType(getFieldFromJsonNode(offer, edcstr + EDCAssetConstant.ASSET_PROP_CONTENTTYPE))
+				.connectorId(getFieldFromJsonNode(contractOfferCatalog, "edc:participantId")).build();
+
+		checkAndSetPolicyPermission(build, policy);
+
+		return build;
+	}
+
+	private void checkAndSetPolicyPermission(QueryDataOfferModel build, JsonNode policy) {
+
+		if (policy != null && policy.isArray()) {
+			policy.forEach(pol -> {
+				JsonNode permission = pol.get("odrl:permission");
+				checkAndSetPolicyPermissionConstraints(build, permission);
+			});
+		} else if (policy != null) {
+			JsonNode permission = policy.get("odrl:permission");
+			checkAndSetPolicyPermissionConstraints(build, permission);
+		}
+	}
+
+	private void checkAndSetPolicyPermissionConstraints(QueryDataOfferModel build, JsonNode permission) {
+
+		JsonNode constraints = permission.get("odrl:constraint");
+
+		List<Policies> usagePolicies = new ArrayList<>();
+
+		if (constraints != null) {
+			JsonNode jsonNode = constraints.get("odrl:and");
+
+			if (jsonNode != null && jsonNode.isArray()) {
+				jsonNode.forEach(constraint -> setConstraint(usagePolicies, constraint));
+			} else if (jsonNode != null) {
+				setConstraint(usagePolicies, jsonNode);
+			}
+		}
+
+		//build.setPolicy(PolicyModel.builder().accessPolicies(null).usagePolicies(usagePolicies).build());
+	}
+
+	private void setConstraint(List<Policies> usagePolicies, JsonNode jsonNode) {
+
+		// All policy recieved in catalog are usage policy ,
+		// accespoliocy already applied for access control,
+		// in this constrain all are usage policy
+
+		String leftOperand = getFieldFromJsonNode(jsonNode, "odrl:leftOperand");
+		String rightOperand = getFieldFromJsonNode(jsonNode, "odrl:rightOperand");
+		Policies policyResponse = UtilityFunctions.identyAndGetUsagePolicy(leftOperand, rightOperand);
+		if (policyResponse != null)
+			usagePolicies.add(policyResponse);
+	}
+
+	private String getFieldFromJsonNode(JsonNode jnode, String fieldName) {
+		if (jnode.get(fieldName) != null)
+			return jnode.get(fieldName).asText();
+		else
+			return "";
+	}
+
+}

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/services/ConsumerControlPanelService.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/services/ConsumerControlPanelService.java
@@ -328,7 +328,7 @@ public class ConsumerControlPanelService extends AbstractEDCStepsHelper {
 		String assetId = edrCachedResponseObj.getAssetId();
 		try {
 			edrRequestHelper.getDataFromProvider(
-					getAuthorizationTokenForDataDownload(edrCachedResponseObj.getTransferProcessId()));
+					getAuthorizationTokenForDataDownload(edrCachedResponseObj.getTransferProcessId()),"");
 		} catch (FeignException e) {
 			log.error("RequestBody: " + e.request());
 			String errorMsg = "FeignExceptionton for verifyEDR token " + assetId + "," + e.status() + "::"

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/services/ContractNegotiationService.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/services/ContractNegotiationService.java
@@ -1,0 +1,217 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.edc.services;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.tractusx.sde.common.exception.ServiceException;
+import org.eclipse.tractusx.sde.edc.entities.request.policies.ActionRequest;
+import org.eclipse.tractusx.sde.edc.enums.Type;
+import org.eclipse.tractusx.sde.edc.facilitator.AbstractEDCStepsHelper;
+import org.eclipse.tractusx.sde.edc.facilitator.ContractNegotiateManagementHelper;
+import org.eclipse.tractusx.sde.edc.facilitator.EDRRequestHelper;
+import org.eclipse.tractusx.sde.edc.model.contractnegotiation.ContractNegotiationDto;
+import org.eclipse.tractusx.sde.edc.model.contractnegotiation.Offer;
+import org.eclipse.tractusx.sde.edc.model.edr.EDRCachedByIdResponse;
+import org.eclipse.tractusx.sde.edc.model.edr.EDRCachedResponse;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContractNegotiationService  extends AbstractEDCStepsHelper {
+	
+	private static final String NEGOTIATED = "NEGOTIATED";
+	private final EDRRequestHelper edrRequestHelper;
+	private static final Integer RETRY = 5;
+	private static final Integer THRED_SLEEP_TIME = 5000;
+	
+	private final ContractNegotiateManagementHelper contractNegotiateManagement;
+	
+	@SneakyThrows
+	public EDRCachedResponse verifyOrCreateContractNegotiation(String connectorId,
+			Map<String, String> extensibleProperty, String recipientURL, ActionRequest action, Offer offer) {
+
+//		if (!offer.getConnectorOfferUrl().endsWith(protocolPath))
+//			recipientURL = recipientURL + protocolPath;
+
+		// Verify if there already EDR process initiated then skip it for again download
+		String assetId = offer.getAssetId();
+		List<EDRCachedResponse> eDRCachedResponseList = edrRequestHelper.getEDRCachedByAsset(assetId);
+		EDRCachedResponse checkContractNegotiationStatus = verifyEDRResponse(eDRCachedResponseList);
+
+		if (checkContractNegotiationStatus == null) {
+			String contractAgreementId = checkandGetContractAgreementId(assetId);
+			if (StringUtils.isBlank(contractAgreementId)) {
+				log.info("The EDR process was not completed, no 'NEGOTIATED' EDR status found "
+						+ "and not valid contract agreementId for " + assetId + ", so initiating EDR process");
+				edrRequestHelper.edrRequestInitiate(recipientURL, connectorId, offer.getOfferId(), assetId, action,
+						extensibleProperty);
+				checkContractNegotiationStatus = verifyEDRRequestStatus(assetId);
+			} else {
+				log.info("There is valid contract agreement exist for " + assetId
+						+ ", so ignoring EDR process initiation");
+				checkContractNegotiationStatus = EDRCachedResponse.builder().agreementId(contractAgreementId)
+						.assetId(assetId).build();
+			}
+		} else {
+			log.info("There was EDR process initiated " + assetId
+					+ ", so ignoring EDR process initiation, going to check EDR status only");
+			if (!NEGOTIATED.equals(checkContractNegotiationStatus.getEdrState()))
+				checkContractNegotiationStatus = verifyEDRRequestStatus(assetId);
+		}
+
+		return checkContractNegotiationStatus;
+	}
+	
+	@SneakyThrows
+	private String checkandGetContractAgreementId(String assetId) {
+		
+		List<JsonNode> contractAgreements = contractNegotiateManagement.getAllContractAgreements(assetId,
+				Type.CONSUMER.name(), 0, 10);
+		String contractAgreementId = null;
+		if (!contractAgreements.isEmpty())
+			for (JsonNode jsonNode : contractAgreements) {
+//				ContractNegotiationDto checkContractAgreementNegotiationStatus = contractNegotiateManagement
+//						.checkContractAgreementNegotiationStatus(getFieldFromJsonNode(jsonNode, "@id"));
+//				if ("FINALIZED".equals(checkContractAgreementNegotiationStatus.getState())) {
+//					contractAgreementId = checkContractAgreementNegotiationStatus.getContractAgreementId();
+//					break;
+//				}
+			}
+
+		return contractAgreementId;
+	}
+	
+	private EDRCachedResponse verifyEDRResponse(List<EDRCachedResponse> eDRCachedResponseList) {
+		EDRCachedResponse eDRCachedResponse = null;
+		if (eDRCachedResponseList != null && !eDRCachedResponseList.isEmpty()) {
+			for (EDRCachedResponse edrCachedResponseObj : eDRCachedResponseList) {
+				String edrState = edrCachedResponseObj.getEdrState();
+				// For EDC connector 5.0 edrState field not supported so checking token
+				// validation by calling direct API
+				if (NEGOTIATED.equalsIgnoreCase(edrState) || isEDRTokenValid(edrCachedResponseObj)) {
+					eDRCachedResponse = edrCachedResponseObj;
+					eDRCachedResponse.setEdrState(NEGOTIATED);
+					break;
+				}
+				eDRCachedResponse = edrCachedResponseObj;
+			}
+		}
+		return eDRCachedResponse;
+	}
+	
+	@SneakyThrows
+	public EDRCachedResponse verifyEDRRequestStatus(String assetId) {
+		EDRCachedResponse eDRCachedResponse = null;
+		String edrStatus = "NewToSDE";
+		List<EDRCachedResponse> eDRCachedResponseList = null;
+		int counter = 1;
+		try {
+			do {
+				if (counter > 1)
+					Thread.sleep(THRED_SLEEP_TIME);
+				
+				eDRCachedResponseList = edrRequestHelper.getEDRCachedByAsset(assetId);
+				eDRCachedResponse = verifyEDRResponse(eDRCachedResponseList);
+
+				if (eDRCachedResponse != null && eDRCachedResponse.getEdrState() != null)
+					edrStatus = eDRCachedResponse.getEdrState();
+
+				log.info("Verifying 'NEGOTIATED' EDC EDR status to download data for '" + assetId
+						+ "', The current status is '" + edrStatus + "', Attempt " + counter);
+				counter++;
+			} while (counter <= RETRY && !NEGOTIATED.equals(edrStatus));
+
+			if (eDRCachedResponse == null) {
+				String contractAgreementId = checkandGetContractAgreementId(assetId);
+				if (StringUtils.isNoneBlank(contractAgreementId)) {
+					eDRCachedResponse = EDRCachedResponse.builder().agreementId(contractAgreementId).assetId(assetId)
+							.build();
+				} else
+					throw new ServiceException("Time out!! unable to get Contract negotiation FINALIZED status");
+			}
+
+		} catch (FeignException e) {
+			log.error("RequestBody: " + e.request());
+			String errorMsg = "FeignExceptionton for asset " + assetId + "," + e.contentUTF8();
+			log.error("Response: " + errorMsg);
+			throw new ServiceException(errorMsg);
+		} catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
+			String errorMsg = "InterruptedException for asset " + assetId + "," + ie.getMessage();
+			log.error(errorMsg);
+			throw new ServiceException(errorMsg);
+		} catch (Exception e) {
+			String errorMsg = "Exception for asset " + assetId + "," + e.getMessage();
+			log.error(errorMsg);
+			throw new ServiceException(errorMsg);
+		}
+		return eDRCachedResponse;
+	}
+
+	@SneakyThrows
+	private boolean isEDRTokenValid(EDRCachedResponse edrCachedResponseObj) {
+		String assetId = edrCachedResponseObj.getAssetId();
+		try {
+			EDRCachedByIdResponse authorizationToken = getAuthorizationTokenForDataDownload(
+					edrCachedResponseObj.getTransferProcessId());
+			edrRequestHelper.getDataFromProvider(authorizationToken, authorizationToken.getEndpoint());
+		} catch (FeignException e) {
+			log.error("FeignException RequestBody: " + e.request());
+			String errorMsg = "FeignExceptionton for verifyEDR token " + assetId + "," + e.status() + "::"
+					+ e.contentUTF8();
+			log.error("FeignException Response: " + errorMsg);
+
+			if (e.status() == 403) {
+				log.error("Got 403 as token status so going to try new EDR token: " + errorMsg);
+				return false;
+			}
+		} catch (Exception e) {
+			String errorMsg = "Exception for asset in isEDRTokenValid " + assetId + "," + e.getMessage();
+			log.error(errorMsg);
+		}
+		return true;
+	}
+
+	
+	@SneakyThrows
+	public EDRCachedByIdResponse getAuthorizationTokenForDataDownload(String transferProcessId) {
+		return edrRequestHelper.getEDRCachedByTransferProcessId(transferProcessId);
+	}
+
+	private String getFieldFromJsonNode(JsonNode jnode, String fieldName) {
+		if (jnode.get(fieldName) != null)
+			return jnode.get(fieldName).asText();
+		else
+			return "";
+	}
+
+}

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/DDTRUrlCacheUtility.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/DDTRUrlCacheUtility.java
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.edc.util;
+
+import java.util.List;
+
+import org.eclipse.tractusx.sde.edc.model.response.QueryDataOfferModel;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DDTRUrlCacheUtility {
+
+	private final EDCAssetLookUp edcAssetLookUp;
+
+	@Cacheable(value = "bpn-ddtr", key = "#bpnNumber")
+	public List<QueryDataOfferModel> getDDTRUrl(String bpnNumber) {
+		return edcAssetLookUp.getEDCAssetsByType(bpnNumber, "data.core.digitalTwinRegistry");
+	}
+
+	@CacheEvict(value = "bpn-ddtr", key = "#bpnNumber")
+	public void removeDDTRUrlCache(String bpnNumber) {
+		log.info("Cleared '" + bpnNumber + "' bpn-ddtr cache");
+	}
+
+	@CacheEvict(value = "bpn-ddtr", allEntries = true)
+	public void cleareDDTRUrlAllCache() {
+		log.info("Cleared All bpn-ddtr cache");
+	}
+
+}

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/EDCAssetLookUp.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/EDCAssetLookUp.java
@@ -1,0 +1,91 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.edc.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.tractusx.sde.edc.model.response.QueryDataOfferModel;
+import org.eclipse.tractusx.sde.edc.services.CatalogResponseBuilder;
+import org.eclipse.tractusx.sde.portal.handler.PortalProxyService;
+import org.eclipse.tractusx.sde.portal.model.ConnectorInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EDCAssetLookUp {
+
+	private final PortalProxyService portalProxyService;
+	private final CatalogResponseBuilder catalogResponseBuilder;
+
+	@Value("${edc.consumer.hostname}")
+	private String consumerHost;
+
+	private String filterExpressionTemplate = """
+			 "filterExpression": [{
+			    "operandLeft": "https://w3id.org/edc/v0.0.1/ns/type",
+			    "operator": "=",
+			    "operandRight": "%s"
+			}]""";
+
+	public List<QueryDataOfferModel> getEDCAssetsByType(String bpnNumber, String assetType) {
+
+		List<ConnectorInfo> connectorInfos = portalProxyService.fetchConnectorInfo(List.of(bpnNumber));
+
+		List<QueryDataOfferModel> offers = new ArrayList<>();
+
+		String filterExpression = String.format(filterExpressionTemplate, assetType);
+
+		connectorInfos.stream().forEach(
+				connectorInfo -> connectorInfo.getConnectorEndpoint().parallelStream().distinct().forEach(connector -> {
+					try {
+						if (!connector.contains(consumerHost)) {
+							
+							List<QueryDataOfferModel> queryDataOfferModel = new ArrayList<>();
+//							catalogResponseBuilder
+//									.queryOnDataOffers(connector, 0, 100, filterExpression);
+
+							log.info("For Connector " + connector + ", found " + assetType + " assets :"
+									+ queryDataOfferModel.size());
+
+							queryDataOfferModel.forEach(each -> each.setConnectorOfferUrl(connector));
+
+							offers.addAll(queryDataOfferModel);
+						
+						} else {
+							log.warn("The Consumer and Provider Connector are same so ignoring it for lookup "
+									+ assetType + " in to " + connector);
+						}
+
+					} catch (Exception e) {
+						log.error("Error while looking EDC catalog for " + assetType + ", " + connector
+								+ ", Exception :" + e.getMessage());
+					}
+				}));
+
+		return offers;
+	}
+
+}

--- a/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/EDCAssetUrlCacheService.java
+++ b/modules/sde-external-services/edc/src/main/java/org/eclipse/tractusx/sde/edc/util/EDCAssetUrlCacheService.java
@@ -1,0 +1,125 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.tractusx.sde.edc.util;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.tractusx.sde.common.exception.ServiceException;
+import org.eclipse.tractusx.sde.edc.entities.request.policies.ActionRequest;
+import org.eclipse.tractusx.sde.edc.entities.request.policies.PolicyConstraintBuilderService;
+import org.eclipse.tractusx.sde.edc.model.contractnegotiation.Offer;
+import org.eclipse.tractusx.sde.edc.model.edr.EDRCachedByIdResponse;
+import org.eclipse.tractusx.sde.edc.model.edr.EDRCachedResponse;
+import org.eclipse.tractusx.sde.edc.model.response.QueryDataOfferModel;
+import org.eclipse.tractusx.sde.edc.services.ContractNegotiationService;
+import org.springframework.stereotype.Service;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EDCAssetUrlCacheService {
+
+	private static final Map<String, LocalDateTime> dDTRmap = new ConcurrentHashMap<>();
+
+	private final ContractNegotiationService contractNegotiationService;
+	private final PolicyConstraintBuilderService policyConstraintBuilderService;
+
+	private final DDTRUrlCacheUtility dDTRUrlCacheUtility;
+
+	@SneakyThrows
+	public EDRCachedByIdResponse verifyAndGetToken(String bpnNumber, QueryDataOfferModel queryDataOfferModel) {
+
+		ActionRequest action = policyConstraintBuilderService
+				.getUsagePoliciesConstraints(null);
+
+		Offer offer = null;
+//		Offer.builder().assetId(queryDataOfferModel.getAssetId())
+//				.offerId(queryDataOfferModel.getOfferId())
+//				.policyId(queryDataOfferModel.getPolicyId())
+//				.connectorId(queryDataOfferModel.getConnectorId())
+//				.connectorOfferUrl(queryDataOfferModel.getConnectorOfferUrl())
+//				.build();
+		try {
+			EDRCachedResponse eDRCachedResponse = contractNegotiationService.verifyOrCreateContractNegotiation(
+					bpnNumber, Map.of(), queryDataOfferModel.getConnectorOfferUrl(), action, offer);
+
+			if (eDRCachedResponse == null) {
+				throw new ServiceException("Time out!! to get 'NEGOTIATED' EDC EDR status to lookup '"
+						+ queryDataOfferModel.getAssetId() + "', The current status is null");
+			} else if (!"NEGOTIATED".equalsIgnoreCase(eDRCachedResponse.getEdrState())) {
+				throw new ServiceException(
+						"Time out!! to get 'NEGOTIATED' EDC EDR status to lookup  '" + queryDataOfferModel.getAssetId()
+								+ "', The current status is '" + eDRCachedResponse.getEdrState() + "'");
+			} else
+				return contractNegotiationService
+						.getAuthorizationTokenForDataDownload(eDRCachedResponse.getTransferProcessId());
+
+		} catch (FeignException e) {
+			log.error("FeignException Request : " + e.request());
+			String errorMsg = "Unable to look up offer because: " + e.contentUTF8();
+			log.error("FeignException : " + errorMsg);
+		} catch (Exception e) {
+			String errorMsg = "Unable to look up offer because: " + e.getMessage();
+			log.error("Exception : " + errorMsg);
+		}
+
+		return null;
+	}
+
+	public List<QueryDataOfferModel> getDDTRUrl(String bpnNumber) {
+
+		LocalDateTime cacheExpTime = dDTRmap.get(bpnNumber);
+		LocalDateTime currDate = LocalDateTime.now();
+
+		if (cacheExpTime == null)
+			cacheExpTime = currDate.plusHours(12);
+		else if (currDate.isAfter(cacheExpTime)) {
+			dDTRUrlCacheUtility.removeDDTRUrlCache(bpnNumber);
+			cacheExpTime = currDate.plusHours(12);
+		}
+		dDTRmap.put(bpnNumber, cacheExpTime);
+		List<QueryDataOfferModel> ddtrUrl = dDTRUrlCacheUtility.getDDTRUrl(bpnNumber);
+		if (ddtrUrl.isEmpty()) {
+			log.info("Found connector list empty so removing existing cache and retry to fetch");
+			removeDDTRUrlCache(bpnNumber);
+			ddtrUrl = dDTRUrlCacheUtility.getDDTRUrl(bpnNumber);
+		}
+		return ddtrUrl;
+	}
+
+	public void clearDDTRUrlCache() {
+		dDTRmap.clear();
+		dDTRUrlCacheUtility.cleareDDTRUrlAllCache();
+	}
+
+	public void removeDDTRUrlCache(String bpnNumber) {
+		dDTRUrlCacheUtility.removeDDTRUrlCache(bpnNumber);
+		dDTRmap.remove(bpnNumber);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 <!--
 /********************************************************************************
  * Copyright (c) 2022 BMW GmbH
- * Copyright (c) 2022, 2023 T-Systems International GmbH
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 T-Systems International GmbH
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -96,34 +96,7 @@
 					<groupId>ch.qos.logback</groupId>
 					<artifactId>logback-classic</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>org.apache.tomcat.embed</groupId>
-					<artifactId>tomcat-embed-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-web</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-webmvc</artifactId>
-				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-core</artifactId>
-			<version>10.1.16</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web</artifactId>
-			<version>6.0.14</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>6.0.14</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

### Added

- Policy-Hub service api integration.
- Added New Policy Entities and pojo classes.
- Draft code of Policies changes.
- Added new classes for file download history
- Added new classes for files for cache ddtr and bpndiscovery twin search 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
