### PR TITLE
[fix|sde-backend] : Fix Open api doc for KICS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [Unreleased]
+### Fixed
+- open api fix in sde-open-api.yml.
 ## [2.3.5] - 2024-02-20
 
 ### Added

--- a/modules/sde-core/src/main/resources/sde-open-api.yml
+++ b/modules/sde-core/src/main/resources/sde-open-api.yml
@@ -173,6 +173,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: string
     post:
@@ -190,6 +191,7 @@ paths:
           application/json:
             schema:
               type: array
+              maxItems: 3
               items:
                 type: string
         required: true
@@ -318,6 +320,7 @@ paths:
           application/json:
             schema:
               type: array
+              maxItems: 3
               items:
                 type: string
         required: true
@@ -328,6 +331,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/ConnectorInfo'
   /{submodel}/public/{uuid}:
@@ -416,6 +420,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: string
   /usecases:
@@ -430,6 +435,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: object
                   additionalProperties:
@@ -463,6 +469,7 @@ paths:
           required: false
           schema:
             type: array
+            maxItems: 3
             items:
               type: string
       responses:
@@ -472,6 +479,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: object
                   additionalProperties:
@@ -507,6 +515,7 @@ paths:
           required: false
           schema:
             type: array
+            maxItems: 3
             items:
               type: string
       responses:
@@ -516,6 +525,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: object
                   additionalProperties:
@@ -608,8 +618,10 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: array
+                  maxItems: 3
                   items:
                     type: string
   /processing-report/{id}:
@@ -648,6 +660,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/ProcessFailureDetails'
   /policy-hub/policy-types:
@@ -673,6 +686,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/PolicyTypeResponse'
   /policy-hub/policy-attributes:
@@ -687,6 +701,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: string
   /ping:
@@ -731,6 +746,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/LegalEntityResponse'
   /getEDCPolicy:
@@ -744,6 +760,7 @@ paths:
           required: true
           schema:
             type: array
+            maxItems: 3
             items:
               $ref: '#/components/schemas/QueryDataOfferRequest'
       responses:
@@ -913,6 +930,7 @@ components:
           type: string
         value:
           type: array
+          maxItems: 3
           items:
             type: string
     SubmodelJsonRequest:
@@ -935,14 +953,17 @@ components:
           type: string
         access_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         usage_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         row_data:
           type: array
+          maxItems: 3
           items:
             type: object
     ConsumerRequest:
@@ -953,12 +974,14 @@ components:
       properties:
         offers:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Offer'
         downloadDataAs:
           type: string
         usage_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
     Offer:
@@ -1024,6 +1047,7 @@ components:
             - OR
         constraints:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Constraint'
     JsonNode:
@@ -1035,6 +1059,7 @@ components:
           type: string
         connectorEndpoint:
           type: array
+          maxItems: 3
           items:
             type: string
     UnifiedBpnValidationResponse:
@@ -1081,10 +1106,12 @@ components:
           type: string
         accessPolicies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         usagePolicies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         numberOfUpdatedItems:
@@ -1109,6 +1136,7 @@ components:
           format: int64
         items:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/ProcessReport'
     ProcessFailureDetails:
@@ -1137,16 +1165,19 @@ components:
           type: string
         type:
           type: array
+          maxItems: 3
           items:
             type: string
         description:
           type: string
         useCase:
           type: array
+          maxItems: 3
           items:
             type: string
         attribute:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/PolicyAttributeResponse'
         technicalEnforced:
@@ -1170,10 +1201,12 @@ components:
           type: string
         access_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         usage_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
     QueryDataOfferRequest:


### PR DESCRIPTION
## Description
### Fixed
- Open API docs update for kics fix
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
