### PR TITLE
[fix|sde-backend] : Postgres vulnerability CVE-2024-1597 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Fixed
 - open api fix in sde-open-api.yml.
+- Fixed Postgres vulnerability CVE-2024-1597.
+
 ## [2.3.5] - 2024-02-20
 
 ### Added
@@ -24,7 +26,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix new dDTR support changes.
 - Fixed Vulnerability logback issue of CVE-2023-6481.
 - Docker image updated to fix vulnerability.
-- Fixed Postgres vulnerability CVE-2024-1597.
 
 ## [2.3.4] - 2023-12-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix new dDTR support changes.
 - Fixed Vulnerability logback issue of CVE-2023-6481.
 - Docker image updated to fix vulnerability.
+- Fixed Postgres vulnerability CVE-2024-1597.
 
 ## [2.3.4] - 2023-12-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [Unreleased]
+### Fixed
+- open api fix in sde-open-api.yml.
 ## [2.3.5] - 2024-02-20
 
 ### Added

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -101,7 +101,7 @@ maven/mavencentral/org.mockito/mockito-junit-jupiter/4.8.1, MIT, approved, clear
 maven/mavencentral/org.objenesis/objenesis/3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/org.postgresql/postgresql/42.6.0, BSD-2-Clause AND Apache-2.0, approved, #9159
+maven/mavencentral/org.postgresql/postgresql/42.7.2, BSD-2-Clause AND Apache-2.0, approved, #11681
 maven/mavencentral/org.projectlombok/lombok/1.18.30, MIT AND LicenseRef-Public-Domain, approved, CQ23907
 maven/mavencentral/org.skyscreamer/jsonassert/1.5.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.9, MIT, approved, #7698

--- a/modules/sde-core/pom.xml
+++ b/modules/sde-core/pom.xml
@@ -76,6 +76,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
+			<version>42.7.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>

--- a/modules/sde-core/src/main/resources/sde-open-api.yml
+++ b/modules/sde-core/src/main/resources/sde-open-api.yml
@@ -173,7 +173,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   type: string
     post:
@@ -191,7 +191,7 @@ paths:
           application/json:
             schema:
               type: array
-              maxItems: 3
+              maxItems: 100
               items:
                 type: string
         required: true
@@ -320,7 +320,7 @@ paths:
           application/json:
             schema:
               type: array
-              maxItems: 3
+              maxItems: 100
               items:
                 type: string
         required: true
@@ -331,7 +331,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   $ref: '#/components/schemas/ConnectorInfo'
   /{submodel}/public/{uuid}:
@@ -420,7 +420,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   type: string
   /usecases:
@@ -435,7 +435,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   type: object
                   additionalProperties:
@@ -469,7 +469,7 @@ paths:
           required: false
           schema:
             type: array
-            maxItems: 3
+            maxItems: 100
             items:
               type: string
       responses:
@@ -479,7 +479,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   type: object
                   additionalProperties:
@@ -515,7 +515,7 @@ paths:
           required: false
           schema:
             type: array
-            maxItems: 3
+            maxItems: 100
             items:
               type: string
       responses:
@@ -525,7 +525,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   type: object
                   additionalProperties:
@@ -618,10 +618,10 @@ paths:
             application/json:
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   type: array
-                  maxItems: 3
+                  maxItems: 100
                   items:
                     type: string
   /processing-report/{id}:
@@ -660,7 +660,7 @@ paths:
             application/json:
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   $ref: '#/components/schemas/ProcessFailureDetails'
   /policy-hub/policy-types:
@@ -686,7 +686,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   $ref: '#/components/schemas/PolicyTypeResponse'
   /policy-hub/policy-attributes:
@@ -701,7 +701,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   type: string
   /ping:
@@ -746,7 +746,7 @@ paths:
             '*/*':
               schema:
                 type: array
-                maxItems: 3
+                maxItems: 100
                 items:
                   $ref: '#/components/schemas/LegalEntityResponse'
   /getEDCPolicy:
@@ -760,7 +760,7 @@ paths:
           required: true
           schema:
             type: array
-            maxItems: 3
+            maxItems: 100
             items:
               $ref: '#/components/schemas/QueryDataOfferRequest'
       responses:
@@ -930,7 +930,7 @@ components:
           type: string
         value:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             type: string
     SubmodelJsonRequest:
@@ -953,17 +953,17 @@ components:
           type: string
         access_policies:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Policies'
         usage_policies:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Policies'
         row_data:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             type: object
     ConsumerRequest:
@@ -974,14 +974,14 @@ components:
       properties:
         offers:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Offer'
         downloadDataAs:
           type: string
         usage_policies:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Policies'
     Offer:
@@ -1047,7 +1047,7 @@ components:
             - OR
         constraints:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Constraint'
     JsonNode:
@@ -1059,7 +1059,7 @@ components:
           type: string
         connectorEndpoint:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             type: string
     UnifiedBpnValidationResponse:
@@ -1106,12 +1106,12 @@ components:
           type: string
         accessPolicies:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Policies'
         usagePolicies:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Policies'
         numberOfUpdatedItems:
@@ -1136,7 +1136,7 @@ components:
           format: int64
         items:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/ProcessReport'
     ProcessFailureDetails:
@@ -1165,19 +1165,19 @@ components:
           type: string
         type:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             type: string
         description:
           type: string
         useCase:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             type: string
         attribute:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/PolicyAttributeResponse'
         technicalEnforced:
@@ -1201,12 +1201,12 @@ components:
           type: string
         access_policies:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Policies'
         usage_policies:
           type: array
-          maxItems: 3
+          maxItems: 100
           items:
             $ref: '#/components/schemas/Policies'
     QueryDataOfferRequest:

--- a/modules/sde-core/src/main/resources/sde-open-api.yml
+++ b/modules/sde-core/src/main/resources/sde-open-api.yml
@@ -173,6 +173,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: string
     post:
@@ -190,6 +191,7 @@ paths:
           application/json:
             schema:
               type: array
+              maxItems: 3
               items:
                 type: string
         required: true
@@ -318,6 +320,7 @@ paths:
           application/json:
             schema:
               type: array
+              maxItems: 3
               items:
                 type: string
         required: true
@@ -328,6 +331,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/ConnectorInfo'
   /{submodel}/public/{uuid}:
@@ -416,6 +420,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: string
   /usecases:
@@ -430,6 +435,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: object
                   additionalProperties:
@@ -463,6 +469,7 @@ paths:
           required: false
           schema:
             type: array
+            maxItems: 3
             items:
               type: string
       responses:
@@ -472,6 +479,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: object
                   additionalProperties:
@@ -507,6 +515,7 @@ paths:
           required: false
           schema:
             type: array
+            maxItems: 3
             items:
               type: string
       responses:
@@ -516,6 +525,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: object
                   additionalProperties:
@@ -608,8 +618,10 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: array
+                  maxItems: 3
                   items:
                     type: string
   /processing-report/{id}:
@@ -648,6 +660,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/ProcessFailureDetails'
   /policy-hub/policy-types:
@@ -673,6 +686,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/PolicyTypeResponse'
   /policy-hub/policy-attributes:
@@ -687,6 +701,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   type: string
   /ping:
@@ -731,6 +746,7 @@ paths:
             '*/*':
               schema:
                 type: array
+                maxItems: 3
                 items:
                   $ref: '#/components/schemas/LegalEntityResponse'
   /getEDCPolicy:
@@ -744,6 +760,7 @@ paths:
           required: true
           schema:
             type: array
+            maxItems: 3
             items:
               $ref: '#/components/schemas/QueryDataOfferRequest'
       responses:
@@ -913,6 +930,7 @@ components:
           type: string
         value:
           type: array
+          maxItems: 3
           items:
             type: string
     SubmodelJsonRequest:
@@ -935,14 +953,17 @@ components:
           type: string
         access_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         usage_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         row_data:
           type: array
+          maxItems: 3
           items:
             type: object
     ConsumerRequest:
@@ -953,12 +974,14 @@ components:
       properties:
         offers:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Offer'
         downloadDataAs:
           type: string
         usage_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
     Offer:
@@ -1024,6 +1047,7 @@ components:
             - OR
         constraints:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Constraint'
     JsonNode:
@@ -1035,6 +1059,7 @@ components:
           type: string
         connectorEndpoint:
           type: array
+          maxItems: 3
           items:
             type: string
     UnifiedBpnValidationResponse:
@@ -1081,10 +1106,12 @@ components:
           type: string
         accessPolicies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         usagePolicies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         numberOfUpdatedItems:
@@ -1109,6 +1136,7 @@ components:
           format: int64
         items:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/ProcessReport'
     ProcessFailureDetails:
@@ -1137,16 +1165,19 @@ components:
           type: string
         type:
           type: array
+          maxItems: 3
           items:
             type: string
         description:
           type: string
         useCase:
           type: array
+          maxItems: 3
           items:
             type: string
         attribute:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/PolicyAttributeResponse'
         technicalEnforced:
@@ -1170,10 +1201,12 @@ components:
           type: string
         access_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
         usage_policies:
           type: array
+          maxItems: 3
           items:
             $ref: '#/components/schemas/Policies'
     QueryDataOfferRequest:


### PR DESCRIPTION
## Description

### Fixed
- Postgres vulnerability CVE-2024-1597 fix

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
