### PR TITLE
chore: change log and version 2.3.6 update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [Unreleased]
+## [2.3.6] - 2024-03-06
 ### Fixed
 - open api fix in sde-open-api.yml.
 - Fixed Postgres vulnerability CVE-2024-1597.
@@ -287,7 +287,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Compliance with Catena-X Guidelines
 - Integration with Digital Twin registry service.
 
-[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.5...main
+[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.6...main
+[2.3.6]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.5...v2.3.6
 [2.3.5]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.4...v2.3.5
 [2.3.4]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.3...v2.3.4
 [2.3.3]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.2...v2.3.3


### PR DESCRIPTION

## Description
[For Rel-24.03]
- open api fix in sde-open-api.yml.
- Fixed Postgres vulnerability CVE-2024-1597.
- Fixed spring security Vulnerability CVE-2024-22234.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
