### PR TITLE
feat : New maven module for part type information submodel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added usecase handle implementation for multiple submodel support.
 - Supported new serial part submodel with multi version support. 
 - Supported new single level bom as built submodel with multi version support. 
+- New maven module for part type information submodel support.
 
 ## [2.3.6] - 2024-03-06
 ### Fixed

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -72,6 +72,7 @@ maven/mavencentral/org.eclipse.tractusx/digital-twins/0.0.1, Apache-2.0, approve
 maven/mavencentral/org.eclipse.tractusx/edc/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx/part-as-planned/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx/part-site-information-as-planned/0.0.1, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx/part-type-information/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx/pcf-exchange/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx/pcf/0.0.1, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx/policy-hub/0.0.1, Apache-2.0, approved, automotive.tractusx

--- a/modules/sde-core/pom.xml
+++ b/modules/sde-core/pom.xml
@@ -162,6 +162,12 @@
 			<artifactId>part-as-planned</artifactId>
 			<version>0.0.1</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.eclipse.tractusx</groupId>
+			<artifactId>part-type-information</artifactId>
+			<version>0.0.1</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.tractusx</groupId>

--- a/modules/sde-submodules/part-type-information/part-type-information.md
+++ b/modules/sde-submodules/part-type-information/part-type-information.md
@@ -1,0 +1,52 @@
+ # PartTypeInformation (SDE Maven module)
+---
+## Description
+
+This module use for PartTypeInformation submodel specification and descriptors. It's contain the codes related to PartTypeInformation to validate, parse and transfer data for DigitalTwins and EDC to create aspect twins and data offer.
+
+---
+#### Version: 1.0.0
+#### PartTypeInformation Aspect Model URN: urn:bamm:io.catenax.part_as_planned:1.0.0#PartTypeInformation
+#### Semantic Id: urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation
+---
+
+### Schema
+
+Please find below links for schema details:
+
+- [PartTypeInformation V1.0.0 schema](src/main/resources/part-type-information-v1.0.0.json)
+
+### CSV file headers
+
+| Headers Name              		| Mandatory                 | Position 	|
+|------------------------	    |---------------------------|--------	|
+| uuid                      		| Yes			            |    1     	|
+| manufacturer_part_id      		| Yes					    |    2    	|
+| classification_standard		| Yes 						| 	 3	   	|
+| classification_id   	      	| Yes                       | 	 4	  	|
+| classification_description	    | No                        | 	 5	  	|
+| function						| Yes						|	 6 		|
+| function_valid_from	    		| No                     	| 	 7	 	|
+| function_valid_until	    		| No                     	| 	 8	 	|
+| name_at_manufacturer	 	    | Yes                       |    9 	 	|
+
+#### [CSV Sample File Link]
+
+#### Example for submodel PartAsPlanned
+
+### Work Flow 
+
+ - CSV to POJO
+ - CSV column validation and mandatory field validation
+ - POJO TO DTO
+ - UUID generate v4
+ - DigitalTwins API's calls 
+ - EDC API's calls
+ - BPN Discovery calls
+ - DB Store
+ 
+### External Services Call
+
+ - DigitalTwins
+ - EDC Connectors
+ - BPN Discovery

--- a/modules/sde-submodules/part-type-information/pom.xml
+++ b/modules/sde-submodules/part-type-information/pom.xml
@@ -1,0 +1,87 @@
+<!--
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tractusx</groupId>
+		<artifactId>sde</artifactId>
+		<version>0.0.1</version>
+		<relativePath>../../../</relativePath>
+	</parent>
+	
+	<artifactId>part-type-information</artifactId>
+	<name>part-type-information</name>
+	<description>part-type-information</description>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.tractusx</groupId>
+			<artifactId>sde-common</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tractusx</groupId>
+			<artifactId>edc</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tractusx</groupId>
+			<artifactId>digital-twins</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tractusx</groupId>
+			<artifactId>bpn-discovery</artifactId>
+			<version>0.0.1</version>
+		</dependency>
+	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.processor.version}</version>
+						</path>
+					</annotationProcessorPaths>
+					<compilerArgs>
+						<compilerArg>
+							-Amapstruct.unmappedTargetPolicy=IGNORE
+						</compilerArg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/modules/sde-submodules/part-type-information/src/main/java/org/eclipse/tractusx/sde/submodels/pti/PartTypeInformationV100.java
+++ b/modules/sde-submodules/part-type-information/src/main/java/org/eclipse/tractusx/sde/submodels/pti/PartTypeInformationV100.java
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.sde.submodels.pti;
+
+import java.io.InputStream;
+
+import org.eclipse.tractusx.sde.common.extensions.SubmodelExtension;
+import org.eclipse.tractusx.sde.common.model.Submodel;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class PartTypeInformationV100 extends SubmodelExtension {
+
+	private Submodel submodel = null;
+
+	@PostConstruct
+	public void init() {
+
+		String resource = "part-type-information-v1.0.0.json";
+		// this is the path within the jar file
+		InputStream input = this.getClass().getResourceAsStream("/resources/" + resource);
+		if (input == null) {
+			// this is how we load file within editor (eg eclipse)
+			input = this.getClass().getClassLoader().getResourceAsStream(resource);
+		}
+
+		submodel = loadSubmodel(input);
+		
+		submodel.addProperties("tableName", "parttypeinformation_v_100");
+	}
+
+	@Override
+	public Submodel submodel() {
+		return submodel;
+	}
+
+}

--- a/modules/sde-submodules/part-type-information/src/main/java/org/eclipse/tractusx/sde/submodels/pti/PartTypeInformationV100.java
+++ b/modules/sde-submodules/part-type-information/src/main/java/org/eclipse/tractusx/sde/submodels/pti/PartTypeInformationV100.java
@@ -38,7 +38,7 @@ public class PartTypeInformationV100 extends SubmodelExtension {
 
 		String resource = "part-type-information-v1.0.0.json";
 		// this is the path within the jar file
-		InputStream input = this.getClass().getResourceAsStream("/resources/" + resource);
+		InputStream input = PartTypeInformationV100.class.getResourceAsStream("/resources/" + resource);
 		if (input == null) {
 			// this is how we load file within editor (eg eclipse)
 			input = this.getClass().getClassLoader().getResourceAsStream(resource);

--- a/modules/sde-submodules/part-type-information/src/main/resources/part-type-information-v1.0.0.json
+++ b/modules/sde-submodules/part-type-information/src/main/resources/part-type-information-v1.0.0.json
@@ -1,0 +1,197 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "http://example.com/example.json",
+	"type": "array",
+	"id": "parttypeinformation_100",
+	"idShort": "partTypeInformation",
+	"version": "1.0.0",
+	"semantic_id": "urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation",
+	"title": "Part Type Information",
+	"shortDescription": "BoM As-Planned - Submodel PartTypeInformation",
+	"description": "A Part Type Information represents an item in the Catena-X Bill of Material (BOM) on a type level in a specific version.",
+	"items": {
+		"type": "object",
+		"required": [
+			"uuid",
+			"manufacturer_part_id",
+			"catenax_site_id",
+			"name_at_manufacturer",
+			"classification_standard",
+			"classification_id",
+			"function"
+		],
+		"dependentRequired": {
+		},
+		"properties": {
+			"uuid": {
+				"type": [
+					"string"
+				],
+				"title": "UUID URN",
+				"description": "The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by \"urn:uuid:\" to make it an IRI.",
+				"minLength": 1,
+				"pattern" : "(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)",
+				"examples": [
+					"urn:uuid:8eea5f45-0823-48ce-a4fc-c3bf1cdfa4c2"
+				]
+			},
+			"manufacturer_part_id": {
+				"type": [
+					"string"
+				],
+				"minLength": 1,
+				"title": "Manufacturer Part Id",
+				"description" : "Part ID as assigned by the manufacturer of the part. The part ID identifies the part in the manufacturer`s dataspace. The part ID references a specific version of a part. The version number must be included in the part ID if it is available. The part ID does not reference a specific instance of a part and must not be confused with the serial number.",
+				"examples": [
+					"123-0.740-3434-A"
+				]
+			},
+			"catenax_site_id": {
+				"type": [
+					"string"
+				],
+				"minLength": 1,
+				"title": "catenaX Site Id",
+				"description": "The identifier of the site according to Catena-X BPDM. The catenaXsiteId must be a valid Catena-X BPN. The BPN is a unique, unchangeable identifier for Business Partners / company locations from foundation to closure, regardless of the different business relationships / structures between or within the Business Partners or company locations.",
+				"examples": [
+					"BPNS1234567890ZZ"
+				]
+			},
+			"classification_standard": {
+				"type": [
+					"string"
+				],
+				"minLength": 1,
+				"title": "Classification Standard",
+				"description": "Identified classification standards that align to the Catena-X needs.",
+				"examples": [
+					"IEC"
+				]
+			},
+			"classification_id": {
+				"type": [
+					"string"
+				],
+				"minLength": 1,
+				"title": "Classification Id",
+				"description": "The classification ID of the part type according to the corresponding standard definition mentioned in the key value pair.",
+				"examples": [
+					"61360- 2:2012"
+				]
+			},
+			"classification_description": {
+				"type": [
+					"string",
+					"null"
+				],
+				"title": "Classification Description",
+				"description": "Optional property describing the classification standard.",
+				"examples": [
+					"Standard data element types with associated classification scheme for electric components."
+				]
+			},
+			"function": {
+				"type": [
+					"string"
+				],
+				"enum": [
+					"production",
+					"warehouse",
+					"spare part warehouse"
+				],
+				"title": "Function",
+				"minLength": 1,
+				"description" : "The function of the site in relation to the part (i.e. the activity within the value chain of the part that is performed at the site).",
+				"examples": [
+					"production"
+				]
+			},
+			"function_valid_from": {
+				"type": [
+					"string",
+					"null"
+				],
+				"title": "Function Valid From",
+				"pattern" : "^(?:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?Z|[0-9]{4}-[0-9]{2}-[0-9]{2}(?:T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2}))?)$",
+				"description" : "Timestamp, from when the site has the specified function for the given part.",
+				"examples": [
+					"2024-01-29T12:00:00.123+02:00"
+				]
+			},
+			"function_valid_until": {
+				"type": [
+					"string",
+					"null"
+				],
+				"title": "Function Valid Until",
+				"pattern" : "^(?:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?Z|[0-9]{4}-[0-9]{2}-[0-9]{2}(?:T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2}))?)$",
+				"description" : "Timestamp, from when the site has the specified function for the given part.",
+				"examples": [
+					"2024-01-29T12:00:00.123+02:00"
+				]
+			},
+			"name_at_manufacturer": {
+				"type": [
+					"string"
+				],
+				"minLength": 1,
+				"title": "Name At Manufacturer",
+				"description": "Name of the part as assigned by the manufacturer",
+				"examples": [
+					"Mirror left"
+				]
+			}
+		}
+	},
+	"examples": [
+		{
+			"uuid": "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d",
+			"manufacturer_part_id": "123-0.740-3434-A",
+			"catenax_site_id": "BPNS1234567890ZZ",
+			"classification_standard": "IEC",
+			"classification_id": "61360- 2:2012",
+			"classification_description": "Standard data element types with associated classification scheme for electric components.",
+			"function": "production",
+			"function_valid_from": "2024-01-29T12:00:00.123+02:00",
+			"function_valid_until": "2024-03-29T12:00:00.123+02:00",
+			"name_at_manufacturer": "Mirror left"
+		}
+	],
+	"addOn": {
+		"identifier": "${uuid}",
+		"lookupShellSpecificAssetIdsSpecs": {
+			"manufacturerPartId": "${manufacturer_part_id}",
+			"assetLifecyclePhase" :"AsPlanned"
+		},
+		"shortIdSpecs": [
+			"${name_at_manufacturer}",
+			"${manufacturer_part_id}"
+		],
+		"createShellIfNotExist": true,
+		"bpnDiscoverySpecs": {
+			"manufacturerPartId": "${manufacturer_part_id}"
+		},
+		"responseTemplate": {
+			"partTypeInformation": {
+				"partClassification": [
+					{
+						"classificationStandard": "${classification_standard}",
+						"classificationID": "${classification_id}",
+						"classificationDescription": "${classification_description}"
+					}
+				],
+				"manufacturerPartId": "${manufacturer_part_id}",
+				"nameAtManufacturer": "${name_at_manufacturer}"
+			},
+			"partSitesInformationAsPlanned": [
+				{
+					"functionValidUntil": "${function_valid_until}",
+					"catenaXsiteId": "${catenax_site_id}",
+					"function": "${function}",
+					"functionValidFrom": "${function_valid_from}"
+				}
+			],
+			"catenaXId": "${uuid}"
+		}
+	}
+}

--- a/modules/sde-submodules/serial-part/src/main/java/org/eclipse/tractusx/sde/submodels/sp/SerialPartV300.java
+++ b/modules/sde-submodules/serial-part/src/main/java/org/eclipse/tractusx/sde/submodels/sp/SerialPartV300.java
@@ -38,7 +38,7 @@ public class SerialPartV300 extends SubmodelExtension {
 
 		String resource = "serial-part-v3.0.0.json";
 		// this is the path within the jar file
-		InputStream input = this.getClass().getResourceAsStream("/resources/" + resource);
+		InputStream input = SerialPartV300.class.getResourceAsStream("/resources/" + resource);
 		if (input == null) {
 			// this is how we load file within editor (eg eclipse)
 			input = this.getClass().getClassLoader().getResourceAsStream(resource);

--- a/modules/sde-submodules/single-level-bom-as-built/src/main/java/org/eclipse/tractusx/sde/submodels/slbab/SingleLevelBomAsBuiltV100.java
+++ b/modules/sde-submodules/single-level-bom-as-built/src/main/java/org/eclipse/tractusx/sde/submodels/slbab/SingleLevelBomAsBuiltV100.java
@@ -38,7 +38,8 @@ public class SingleLevelBomAsBuiltV100 extends SubmodelExtension {
 
 		String resource = "single-level-bom-as-built-v1.0.0.json";
 		// this is the path within the jar file
-		InputStream input = this.getClass().getResourceAsStream("/resources/" + resource);
+		//InputStream input = this.getClass().getResourceAsStream("/resources/" + resource);
+		InputStream input = SingleLevelBomAsBuiltV100.class.getResourceAsStream("/resources/" + resource);
 		if (input == null) {
 			// this is how we load file within editor (eg eclipse)
 			input = this.getClass().getClassLoader().getResourceAsStream(resource);

--- a/modules/sde-submodules/single-level-bom-as-built/src/main/java/org/eclipse/tractusx/sde/submodels/slbab/SingleLevelBomAsBuiltV300.java
+++ b/modules/sde-submodules/single-level-bom-as-built/src/main/java/org/eclipse/tractusx/sde/submodels/slbab/SingleLevelBomAsBuiltV300.java
@@ -37,7 +37,7 @@ public class SingleLevelBomAsBuiltV300 extends SubmodelExtension {
 
 		String resource = "single-level-bom-as-built-v3.0.0.json";
 		// this is the path within the jar file
-		InputStream input = this.getClass().getResourceAsStream("/resources/" + resource);
+		InputStream input = SingleLevelBomAsBuiltV300.class.getResourceAsStream("/resources/" + resource);
 		if (input == null) {
 			// this is how we load file within editor (eg eclipse)
 			input = this.getClass().getClassLoader().getResourceAsStream(resource);

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
 		<module>modules/sde-submodules/batch</module>
 		<module>modules/sde-submodules/single-level-bom-as-built</module>
 		<module>modules/sde-submodules/part-as-planned</module>
+		<module>modules/sde-submodules/part-type-information</module>
 		<module>modules/sde-submodules/single-level-bom-as-planned</module>
 		<module>modules/sde-submodules/part-site-information-as-planned</module>
 		<module>modules/sde-submodules/single-level-usage-as-built</module>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- Added new maven module for part type information submodel support.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
