### PR TITLE
fix | dependabot bump version fix

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # fetch-depth: 0 is required to determine differences in chart(s)
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -53,6 +53,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.4.6
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/code-ql.yaml
+++ b/.github/workflows/code-ql.yaml
@@ -61,7 +61,7 @@ jobs:
      #Setup Java 17
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4 
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Upload DEPENDENCIES file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: DEPENDENCIES
         if: steps.dependencies-changed.outputs.changed == 'true'

--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 18
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '18'
           distribution: 'temurin'
@@ -80,7 +80,7 @@ jobs:
            password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
            context: .
            file: ./build/Dockerfile
@@ -93,7 +93,7 @@ jobs:
        # Important step to push image description to DockerHub 
       - name: Update Docker Hub description
         if: github.event_name != 'pull_request'
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
            # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
            # readme-filepath: path/to/dedicated/notice-for-docker-image.md 

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -42,7 +42,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: KICS scan
         uses: checkmarx/kics-github-action@master

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,8 +28,8 @@ on:
   # Trigger manually
 
 jobs:
-
-  analyze-config:
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Remove garbage character from 'edc_request_template' path. Fixed [#147](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/issues/147).
 - Dependabot bump version fix in pom.xml and DEPENDENCIES file update.
+- Dockerfile image update. [#117](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/pull/117)
 
 
 ## [2.3.6] - 2024-03-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Remove garbage character from 'edc_request_template' path. Fixed [#147](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/issues/147).
+- Dependabot bump version fix in pom.xml and DEPENDENCIES file update.
 
 
 ## [2.3.6] - 2024-03-06

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -26,7 +26,6 @@ maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-io/commons-io/2.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
-maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
 maven/mavencentral/io.github.openfeign.form/feign-form-spring/3.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.openfeign.form/feign-form/3.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.openfeign/feign-core/12.3, Apache-2.0, approved, clearlydefined
@@ -34,9 +33,9 @@ maven/mavencentral/io.github.openfeign/feign-slf4j/12.3, Apache-2.0, approved, c
 maven/mavencentral/io.micrometer/micrometer-commons/1.11.6, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
 maven/mavencentral/io.micrometer/micrometer-observation/1.11.6, Apache-2.0, approved, #9242
 maven/mavencentral/io.smallrye/jandex/3.0.5, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
-maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
-maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.7, Apache-2.0, approved, #5919
+maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.21, Apache-2.0, approved, #5947
+maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.21, Apache-2.0, approved, #5929
+maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.21, Apache-2.0, approved, #5919
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, ee4j.cdi
@@ -96,7 +95,7 @@ maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approv
 maven/mavencentral/org.junit.jupiter/junit-jupiter/5.9.3, EPL-2.0, approved, #6972
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.3, EPL-2.0, approved, #3130
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.3, EPL-2.0, approved, #3128
-maven/mavencentral/org.mapstruct/mapstruct/1.4.2.Final, Apache-2.0, approved, #2483
+maven/mavencentral/org.mapstruct/mapstruct/1.5.5.Final, Apache-2.0, approved, #6277
 maven/mavencentral/org.mockito/mockito-core/4.8.1, MIT, approved, clearlydefined
 maven/mavencentral/org.mockito/mockito-junit-jupiter/4.8.1, MIT, approved, clearlydefined
 maven/mavencentral/org.objenesis/objenesis/3.2, Apache-2.0, approved, clearlydefined
@@ -107,9 +106,9 @@ maven/mavencentral/org.projectlombok/lombok/1.18.30, MIT AND LicenseRef-Public-D
 maven/mavencentral/org.skyscreamer/jsonassert/1.5.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.9, MIT, approved, #7698
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.2, Apache-2.0, approved, #5920
-maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.2, Apache-2.0, approved, #5950
-maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.2, Apache-2.0, approved, #5923
+maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.5.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.5.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.5.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.6, Apache-2.0, approved, #9341
 maven/mavencentral/org.springframework.boot/spring-boot-devtools/3.1.6, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.6, Apache-2.0, approved, #9338
@@ -157,7 +156,6 @@ maven/mavencentral/org.springframework/spring-test/6.0.14, Apache-2.0, approved,
 maven/mavencentral/org.springframework/spring-tx/6.0.14, Apache-2.0, approved, #5926
 maven/mavencentral/org.springframework/spring-web/6.0.14, Apache-2.0, approved, #5942
 maven/mavencentral/org.springframework/spring-webmvc/6.0.14, Apache-2.0, approved, #5944
-maven/mavencentral/org.webjars/swagger-ui/4.15.5, Apache-2.0 AND MIT, approved, #5921
-maven/mavencentral/org.webjars/webjars-locator-core/0.52, MIT, approved, clearlydefined
+maven/mavencentral/org.webjars/swagger-ui/5.13.0, Apache-2.0, approved, #14547
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 # our base build image
-FROM maven:3.9.5-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-17-focal AS build
 
 # copy the project files
 COPY ../pom.xml ./pom.xml
@@ -31,7 +31,7 @@ RUN mvn clean install
 
 # our final base image
 
-FROM eclipse-temurin:17.0.10_7-jdk-focal
+FROM eclipse-temurin:19.0.2_7-jdk-focal
 
 ARG USERNAME=sdeuser
 ARG USER_UID=1001

--- a/modules/sde-core/pom.xml
+++ b/modules/sde-core/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.0.2</version>
+			<version>2.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -101,11 +101,6 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-config</artifactId>
 			<version>6.1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.mapstruct</groupId>
-			<artifactId>mapstruct</artifactId>
-			<version>1.4.2.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 		<java.version>17</java.version>
 		<log4j2.version>2.17.1</log4j2.version>
 		<spring-cloud.version>2022.0.3</spring-cloud.version>
-		<org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
-		<org.mapstruct.processor.version>1.4.2.Final</org.mapstruct.processor.version>
+		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+		<org.mapstruct.processor.version>1.5.5.Final</org.mapstruct.processor.version>
 		<snakey-version>2.0</snakey-version>
 	</properties>
 
@@ -173,7 +173,7 @@
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
-			<version>1.4.2.Final</version>
+			<version>${org.mapstruct.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -212,7 +212,7 @@
 				<plugin>
 					<groupId>org.eclipse.dash</groupId>
 					<artifactId>license-tool-plugin</artifactId>
-					<version>1.0.3-SNAPSHOT</version>
+					<version>1.1.0</version>
 					<configuration>
 						<projectId>automotive.tractusx</projectId>
 						<!-- name of dependencies file -->


### PR DESCRIPTION


## Description
- Dependabot bump version fix in pom.xml and DEPENDENCIES file update

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
