### PR TITLE
chore docker notice.md updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [2.3.8] - 2024-05-14
+## [2.4.0] - 2024-05-14
 
 ### Added
 - Updated readme.md and open api yml file.
@@ -331,8 +331,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Compliance with Catena-X Guidelines
 - Integration with Digital Twin registry service.
 
-[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.8...main
-[2.3.8]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.7...v2.3.8
+[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.4.0...main
+[2.4.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.7...v2.4.0
 [2.3.7]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.6...v2.3.7
 [2.3.6]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.5...v2.3.6
 [2.3.5]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.4...v2.3.5

--- a/DOCKER_NOTICE.md
+++ b/DOCKER_NOTICE.md
@@ -12,7 +12,7 @@ Eclipse Tractus-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0] https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/blob/main/LICENSE
 
 **Used base image**
-- [eclipse-temurin:17.0.10_7-jdk-focal](https://github.com/adoptium/containers)
+- [eclipse-temurin:19.0.2_7-jdk-focal](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin  
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin  
 - Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin


### PR DESCRIPTION
## Description

- chore docker notice.md updated with docker image.
- changelog updated.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
