### PR TITLE
fix :  Added fix for issue #191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [2.3.8] - 2024-06-20
+### Fixed
+-  Added fix for issue #191 (https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/issues/191).
+
 ## [2.3.7] - 2024-05-09 
 ### Fixed
 - Rename edc_request_template directory.
@@ -292,7 +296,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Compliance with Catena-X Guidelines
 - Integration with Digital Twin registry service.
 
-[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.7...release-24-03-hotfix
+[unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.8...release-24-03-hotfix
+[2.3.8]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.7...v2.3.8
 [2.3.7]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.6...v2.3.7
 [2.3.6]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.5...v2.3.6
 [2.3.5]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.4...v2.3.5

--- a/modules/sde-core/src/main/resources/flyway/V22__add_new_role_for_download.sql
+++ b/modules/sde-core/src/main/resources/flyway/V22__add_new_role_for_download.sql
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('consumer_subscribe_download_data_offers','Allows consumer user to subscribe and download data');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('consumer_download_data_offer','Allows consumer user to download data again');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('consumer_view_download_history','Allows consumer user to view download data history');	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('consumer_subscribe_download_data_offers','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('consumer_download_data_offer','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('consumer_view_download_history','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('consumer_download_data_offer','User');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('consumer_view_download_history','User');

--- a/modules/sde-core/src/main/resources/flyway/V23__add_new_role_for_auto_config.sql
+++ b/modules/sde-core/src/main/resources/flyway/V23__add_new_role_for_auto_config.sql
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('auto_config_management','Allows Admin user to update auto upload configuration');
+
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('policy_management','Allows Admin user to add/update/delete policy configuration');
+
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('auto_config_management','Admin');
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policy_management','Admin');
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policy_management','Creator');

--- a/modules/sde-core/src/main/resources/flyway/V24__Alter_process_report_table.sql
+++ b/modules/sde-core/src/main/resources/flyway/V24__Alter_process_report_table.sql
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+ALTER TABLE process_report ADD policy_uuid varchar NULL;
+
+ALTER TABLE process_report ALTER COLUMN usage_policy TYPE text USING usage_policy::text;

--- a/modules/sde-core/src/main/resources/flyway/V25__add_new_role_for_pcf_exchange.sql
+++ b/modules/sde-core/src/main/resources/flyway/V25__add_new_role_for_pcf_exchange.sql
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('search_pcf','Search PCF value in consumer section');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('request_for_pcf_value','Request for PCF value');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('action_on_pcf_request','Action on PCF request');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('view_pcf_history','View PCF history in provider and consumer');
+
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('search_pcf','User');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('view_pcf_history','User');
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('action_on_pcf_request','Admin');
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('search_pcf','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('request_for_pcf_value','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('view_pcf_history','Creator');

--- a/modules/sde-core/src/main/resources/flyway/V26__add_new_role_for_policy_hub.sql
+++ b/modules/sde-core/src/main/resources/flyway/V26__add_new_role_for_policy_hub.sql
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('policyhub_view_policy_attributes','View policy attributes');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('policyhub_view_policy_types','View policy types');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('policyhub_view_policy_content','View policy content');
+INSERT INTO sde_permission (sde_permission,description)
+	VALUES ('policyhub_policy_content','Allow user to create policy content');
+
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_view_policy_attributes','User');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_view_policy_types','User');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_view_policy_content','User');
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_policy_content','Admin');
+	
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_view_policy_attributes','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_view_policy_types','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_view_policy_content','Creator');
+INSERT INTO sde_role_permission_mapping (sde_permission,sde_role)
+	VALUES ('policyhub_policy_content','Creator');

--- a/modules/sde-core/src/main/resources/flyway/V27__Alter_process_report_table.sql
+++ b/modules/sde-core/src/main/resources/flyway/V27__Alter_process_report_table.sql
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2024 T-Systems International GmbH
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+ALTER TABLE process_report RENAME COLUMN bpn_numbers TO access_policies;
+ALTER TABLE process_report RENAME COLUMN usage_policy TO usage_policies;


### PR DESCRIPTION
## Description

- fixed issue Database Migrations missing for image '2.3.7'[ #191 ] 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
