### PR TITLE
chore trivy workflow update & dependabot issue fixed.

### DIFF
--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -80,7 +80,7 @@ jobs:
            password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
            context: .
            file: ./build/Dockerfile

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.23.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: "tractusx/managed-simple-data-exchanger-backend:latest" # Pull image from Docker Hub and run Trivy vulnerability scanner
           format: "sarif"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,14 +38,15 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.23.0
         with:
           image-ref: "tractusx/managed-simple-data-exchanger-backend:latest" # Pull image from Docker Hub and run Trivy vulnerability scanner
           format: "sarif"
           output: "trivy-results.sarif"
-          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
           severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
           hide-progress: false
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Description

- trivy workflow update.
- dependabot issues fix.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
