### PR TITLE
chore updated change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [Unreleased]
+## [2.4.3] - 2024-05-30
 
 ### Added
 - New changes for PCF v7.0.0 support.
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Dependabot bump jar version fixed.
 - Trivy high security issue fixed for CVE-2024-34750.  
 
+## [2.4.2] - 2024-05-31 [deprecated] 
 
 ## [2.4.1] - 2024-05-24
 
@@ -363,6 +364,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Integration with Digital Twin registry service.
 
 [unreleased]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.4.1...main
+
 [2.4.1]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.7...v2.4.0
 [2.3.7]: https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend/compare/v2.3.6...v2.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-## [2.4.3] - 2024-05-30
+## [2.4.3] - 2024-05-31
 
 ### Added
 - New changes for PCF v7.0.0 support.
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Dependabot bump jar version fixed.
 - Trivy high security issue fixed for CVE-2024-34750.  
 
-## [2.4.2] - 2024-05-31 [deprecated] 
+## [2.4.2] - 2024-05-30 [deprecated] 
 
 ## [2.4.1] - 2024-05-24
 


### PR DESCRIPTION
## Description
- change log  appversion v2.4.3.
- v2.4.2 deprecated.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
